### PR TITLE
🎨 Palette: Add Haptic Feedback to Task Completion – 2023-10-27

### DIFF
--- a/lib/features/task_management/presentation/widgets/task_tile.dart
+++ b/lib/features/task_management/presentation/widgets/task_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:app/features/task_management/domain/entities/task.dart';
 import 'package:app/features/task_management/presentation/bloc/tasks_bloc.dart';
@@ -45,9 +46,12 @@ class _TaskTileState extends State<TaskTile> {
             child: Row(
               children: [
                 GestureDetector(
-                  onTap: () => context
-                      .read<TasksBloc>()
-                      .add(ToggleTaskCompletion(widget.task.id)),
+                  onTap: () {
+                    HapticFeedback.lightImpact();
+                    context
+                        .read<TasksBloc>()
+                        .add(ToggleTaskCompletion(widget.task.id));
+                  },
                   child: AnimatedContainer(
                     duration: 200.ms,
                     width: 26,


### PR DESCRIPTION
Adds a subtle haptic pulse (`HapticFeedback.lightImpact`) when a user taps the checkmark to complete a task to provide satisfying, non-visual confirmation of the action, making the interface feel more responsive and delightful.

---
*PR created automatically by Jules for task [11493304447106591781](https://jules.google.com/task/11493304447106591781) started by @Mahdi-mortazavi*