### PR TITLE
Add automated arm64-v8a release pipeline, refresh README branding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release (Android arm64-v8a)
+
+# Builds a release APK for the arm64-v8a architecture (the vast majority of
+# real Android devices) and publishes it as a polished GitHub Release.
+#
+# Trigger either by pushing a tag like "v1.1.0", or manually from the
+# Actions tab with a version to use.
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to release, e.g. v1.1.0'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - run: flutter pub get
+
+      - name: Build arm64-v8a release APK
+        run: flutter build apk --release --target-platform android-arm64 --split-per-abi
+
+      - name: Rename artifact for a clean download name
+        id: artifact
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          src="build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
+          dest="build/app/outputs/flutter-apk/Nava-${version}-android-arm64.apk"
+          mv "$src" "$dest"
+          echo "path=$dest" >> "$GITHUB_OUTPUT"
+          echo "name=$(basename "$dest")" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: "🍎 Nava ${{ steps.version.outputs.version }}"
+          generate_release_notes: true
+          files: ${{ steps.artifact.outputs.path }}
+          body: |
+            <div align="center">
+
+            ### هنرِ حذف کردن اضافات — The Art of Reduction
+
+            </div>
+
+            یک تجربه‌ی متمرکز و بی‌نویز برای مدیریت کارها و تمرکز عمیق — ساخته‌شده با Flutter، معماری Riverpod و رابط کاربری شیشه‌ای (Liquid Glass).
+
+            ### 📦 دانلود / Download
+
+            | فایل | معماری | حداقل نسخه اندروید |
+            |---|---|---|
+            | **`${{ steps.artifact.outputs.name }}`** | `arm64-v8a` | Android 5.0 (API 21)+ |
+
+            > این بیلد فقط برای معماری **arm64-v8a** است — معماری تقریباً تمام گوشی‌ها و تبلت‌های اندرویدی تولید ۲۰۱۵ به بعد.
+            > This build targets **arm64-v8a** only — the architecture used by virtually every Android phone made since ~2015.
+
+            ### ✨ نکات این نسخه / Highlights
+            - رابط کاربری Liquid Glass با بلور و انیمیشن‌های ارگانیک در سراسر اپ
+            - موتور هپتیک اختصاصی با الگوی لمسی جدا برای هر رویداد (تکمیل کار، هشدار، پایان تایمر)
+            - یادآوری‌های دقیق با پشتیبانی از منطقه‌ی زمانی و بازیابی یادآوری‌های ازدست‌رفته
+            - تایمر تمرکز مقاوم در برابر بک‌گراند شدن اپ — بدون drift، حتی اگر پردازه توسط سیستم‌عامل معلق شود
+
+            ---
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -12,25 +12,70 @@
   <p style="font-size: 1.1em; color: #666;">
     <b>هنرِ حذف کردن اضافات | The Art of Reduction</b>
   </p>
+  <p style="max-width: 560px; margin: 8px auto 0; color: #555;">
+    A minimalist <b>Flutter</b> to-do &amp; deep-focus timer app with a <b>Liquid Glass</b> UI,
+    a <b>Riverpod</b>-powered architecture, and a background-safe focus session that never drifts.
+  </p>
 
+  <p>
+    <a href="https://github.com/Mahdi-mortazavi/app/releases/latest">
+      <img src="https://img.shields.io/github/v/release/Mahdi-mortazavi/app?style=for-the-badge&label=latest&color=0A84FF" alt="Latest release">
+    </a>
+    <a href="https://github.com/Mahdi-mortazavi/app/releases">
+      <img src="https://img.shields.io/github/downloads/Mahdi-mortazavi/app/total?style=for-the-badge&color=32D74B" alt="Downloads">
+    </a>
+    <a href="https://github.com/Mahdi-mortazavi/app/stargazers">
+      <img src="https://img.shields.io/github/stars/Mahdi-mortazavi/app?style=for-the-badge&color=FF9F0A" alt="Stars">
+    </a>
+  </p>
   <p>
     <a href="https://flutter.dev">
       <img src="https://img.shields.io/badge/Flutter-3.19%2B-02569B?style=for-the-badge&logo=flutter&logoColor=white" alt="Flutter">
     </a>
-    <a href="https://dart.dev">
-      <img src="https://img.shields.io/badge/Dart-3.0%2B-0175C2?style=for-the-badge&logo=dart&logoColor=white" alt="Dart">
+    <a href="https://riverpod.dev">
+      <img src="https://img.shields.io/badge/State-Riverpod-1B1B1F?style=for-the-badge&logo=dart&logoColor=white" alt="Riverpod">
     </a>
     <a href="#">
-      <img src="https://img.shields.io/badge/Design-Minimalist-222222?style=for-the-badge&logo=apple&logoColor=white" alt="Design">
+      <img src="https://img.shields.io/badge/Design-Liquid_Glass-222222?style=for-the-badge&logo=apple&logoColor=white" alt="Design">
     </a>
   </p>
 
   <!-- DOWNLOAD BADGE -->
   <a href="https://github.com/Mahdi-mortazavi/app/releases/latest">
-    <img src="https://img.shields.io/badge/⬇️_دانلود_نسخه_اندروید_(APK)-3DDC84?style=for-the-badge&logo=android&logoColor=white&height=50" height="40">
+    <img src="https://img.shields.io/badge/⬇️_دانلود_نسخه_اندروید_(arm64--v8a_APK)-3DDC84?style=for-the-badge&logo=android&logoColor=white&height=50" height="40">
   </a>
 
 </div>
+
+<br>
+<hr>
+
+<!-- ======================================================= -->
+<!-- INSTALL                                                 -->
+<!-- ======================================================= -->
+<h2 align="center">📲 نصب / Install</h2>
+
+<div align="center">
+
+جدیدترین نسخه‌ی اندروید (بیلد `arm64-v8a`، سازگار با اکثر گوشی‌های ۲۰۱۵ به بعد) را از صفحه‌ی
+**[Releases](https://github.com/Mahdi-mortazavi/app/releases/latest)** دانلود کنید.
+
+Download the latest Android build (`arm64-v8a`) from the **[Releases page](https://github.com/Mahdi-mortazavi/app/releases/latest)**.
+
+</div>
+
+<details>
+<summary><b>🛠️ ساخت از سورس / Build from source</b></summary>
+
+```bash
+git clone https://github.com/Mahdi-mortazavi/app.git
+cd app
+flutter pub get
+flutter run                       # debug, on a connected device/emulator
+flutter build apk --release --target-platform android-arm64 --split-per-abi
+```
+
+</details>
 
 <br>
 <hr>
@@ -115,12 +160,23 @@
 
 ## 🇺🇸 About the Project
 
-**Nava** is a rebellion against cluttered productivity tools. Developed with **Flutter**, it emphasizes "Invisible Design"—where the interface steps back so you can focus on your tasks.
+**Nava** is a minimalist **Flutter task management & focus timer app** — a rebellion against
+cluttered to-do lists. It pairs a **Liquid Glass** interface (deep blurs, tint gradients, hairline
+borders, physics-based micro-interactions) with a clean **Riverpod** architecture, so the UI stays
+buttery-smooth while the codebase stays maintainable.
 
 ### 🌟 Key Features
-*   **Gestural Interface:** Swipe to complete, hold to edit. No tiny buttons.
-*   **Smart Animations:** The UI breathes and bounces, making productivity feel organic.
-*   **Performance:** Optimized for 60fps+ rendering on Android & iOS.
+*   **🧊 Liquid Glass UI** — translucent, blurred glass surfaces replace flat cards everywhere,
+    with organic press animations instead of static taps.
+*   **🎯 Deep Focus Timer** — a background-safe session timer: time is derived from wall-clock
+    deltas, not a counter, so it never drifts even if the app is suspended or killed mid-session.
+*   **📳 Haptic Engine** — distinct tactile patterns for success, warnings, selection, and timer
+    completion, instead of one generic vibration.
+*   **⏰ Reliable Reminders** — exact alarms with automatic fallback, real timezone resolution, and
+    recovery for reminders missed while the app was closed.
+*   **📌 Pins, Subtasks & Categories** — organize tasks the way you actually think, not the way a
+    spreadsheet does.
+*   **🌗 Persian (Jalali) Calendar** — built-in, first-class support for the Persian date system.
 
 </div>
 
@@ -152,6 +208,17 @@
   </table>
 
   <br>
-  <p>Made with ❤️ in <b>Flutter</b></p>
-  
+  <p>Made with ❤️ in <b>Flutter</b> &middot; State managed by <b>Riverpod</b></p>
+
+  <br>
+
+  <p>
+    اگه Nava رو دوست داشتید، یک ⭐ فراموش نشه — کمک می‌کنه اپ بیشتر دیده بشه!<br>
+    <sub>If you like Nava, please consider starring the repo — it genuinely helps others find it.</sub>
+  </p>
+
+  <a href="https://github.com/Mahdi-mortazavi/app/stargazers">
+    <img src="https://img.shields.io/badge/⭐_Star_this_repo-FFD60A?style=for-the-badge&logo=github&logoColor=black" alt="Star this repo">
+  </a>
+
 </div>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: app
 description: "Nava - A minimalist productivity app inspired by Jony Ive."
 publish_to: 'none'
-version: 1.0.0+1
+version: 1.1.0+2
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
- New GitHub Actions workflow builds a release APK for arm64-v8a and publishes it as a polished, bilingual GitHub Release (triggered by a version tag push or manual dispatch).
- README: added release/downloads/stars badges, an install section (release APK + build-from-source), and replaced aspirational feature copy with an accurate description of what's actually implemented (Liquid Glass UI, Riverpod, haptics engine, background-safe timer, reminder recovery).
- Bumped app version to 1.1.0+2 ahead of the first post-refactor release.