### PR TITLE
Accessibility, motion & polish pass (Apple-grade review)

### DIFF
--- a/lib/core/theme/app_spacing.dart
+++ b/lib/core/theme/app_spacing.dart
@@ -1,0 +1,33 @@
+/// Spacing, radius, and touch-target tokens on a consistent 4pt grid.
+///
+/// Before this, layout constants (24 / 16 / 12 / 28 …) were repeated as magic
+/// numbers across every widget. Centralizing them keeps rhythm consistent and
+/// makes a global spacing change a one-line edit.
+class AppSpacing {
+  const AppSpacing._();
+
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 24;
+  static const double xxl = 32;
+
+  /// Standard screen gutter.
+  static const double gutter = 24;
+
+  /// Apple HIG minimum interactive target. Any tappable control smaller than
+  /// this visually should still occupy at least this much hit area.
+  static const double minTouchTarget = 44;
+}
+
+class AppRadius {
+  const AppRadius._();
+
+  static const double sm = 14;
+  static const double md = 20;
+  static const double lg = 24;
+  static const double xl = 28;
+  static const double sheet = 32;
+  static const double pill = 40;
+}

--- a/lib/core/utils/formatting.dart
+++ b/lib/core/utils/formatting.dart
@@ -1,0 +1,36 @@
+/// Formatting helpers. The app's UI is Persian/RTL, so numbers shown to the
+/// user (timer, counts, reminder times) should use Persian digits for visual
+/// consistency with the Jalali date in the header — mixing Latin and Persian
+/// numerals in one RTL screen reads as unfinished.
+class Fmt {
+  const Fmt._();
+
+  static const _persianDigits = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹'];
+
+  /// Converts every ASCII digit in [input] to its Persian equivalent.
+  static String fa(String input) {
+    final buffer = StringBuffer();
+    for (final rune in input.runes) {
+      if (rune >= 0x30 && rune <= 0x39) {
+        buffer.write(_persianDigits[rune - 0x30]);
+      } else {
+        buffer.write(String.fromCharCode(rune));
+      }
+    }
+    return buffer.toString();
+  }
+
+  /// `mm:ss`, zero-padded, Persian digits. Used by the focus timer.
+  static String clock(int totalSeconds) {
+    final m = (totalSeconds ~/ 60).toString().padLeft(2, '0');
+    final s = (totalSeconds % 60).toString().padLeft(2, '0');
+    return fa('$m:$s');
+  }
+
+  /// `HH:mm`, both fields zero-padded, Persian digits. Used for reminders.
+  static String timeOfDay(DateTime time) {
+    final h = time.hour.toString().padLeft(2, '0');
+    final m = time.minute.toString().padLeft(2, '0');
+    return fa('$h:$m');
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,8 +18,14 @@ Future<void> main() async {
 
   // Notifications need timezone data loaded before any reminder can be
   // scheduled, so this awaits before the first frame rather than racing it.
+  // A failure here (e.g. a plugin/platform hiccup) must never block launch —
+  // the app is fully usable without notifications, so we degrade gracefully.
   final container = ProviderContainer();
-  await container.read(notificationServiceProvider).init();
+  try {
+    await container.read(notificationServiceProvider).init();
+  } catch (e, stack) {
+    debugPrint('Notification init failed, continuing without it: $e\n$stack');
+  }
 
   runApp(
     UncontrolledProviderScope(
@@ -38,10 +44,23 @@ class NavaApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'Nava',
       theme: AppTheme.light,
-      builder: (context, child) => Directionality(
-        textDirection: TextDirection.rtl,
-        child: child!,
-      ),
+      builder: (context, child) {
+        // Honor the system Dynamic Type setting, but clamp the upper bound so
+        // the largest accessibility sizes scale text without shattering the
+        // glass layouts (which have fixed-height rows and pinned cards).
+        final mq = MediaQuery.of(context);
+        final clamped = mq.textScaler.clamp(
+          minScaleFactor: 0.9,
+          maxScaleFactor: 1.35,
+        );
+        return MediaQuery(
+          data: mq.copyWith(textScaler: clamped),
+          child: Directionality(
+            textDirection: TextDirection.rtl,
+            child: child!,
+          ),
+        );
+      },
       home: const HomeScreen(),
     );
   }

--- a/lib/presentation/screens/focus_page.dart
+++ b/lib/presentation/screens/focus_page.dart
@@ -6,8 +6,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:percent_indicator/circular_percent_indicator.dart';
 
 import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_spacing.dart';
 import '../../core/theme/app_typography.dart';
 import '../../core/theme/liquid_glass.dart';
+import '../../core/utils/formatting.dart';
 import '../../data/models/task.dart';
 import '../../providers/focus_timer_provider.dart';
 import '../../providers/task_providers.dart';
@@ -56,111 +58,198 @@ class _FocusPageState extends ConsumerState<FocusPage> with WidgetsBindingObserv
 
   @override
   Widget build(BuildContext context) {
-    final session = ref.watch(focusTimerProvider);
-    if (session == null) return const SizedBox.shrink();
-
-    final remaining = session.remainingSeconds;
-    final minutes = (remaining ~/ 60).toString().padLeft(2, '0');
-    final seconds = (remaining % 60).toString().padLeft(2, '0');
+    // Watch only the two booleans that change page structure — NOT the whole
+    // session — so the per-second timer tick rebuilds just the readout subtree
+    // below, not this entire tree + the glow + the controls.
+    final completed =
+        ref.watch(focusTimerProvider.select((s) => s?.completed ?? false));
+    final isRunning =
+        ref.watch(focusTimerProvider.select((s) => s?.isRunning ?? false));
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
 
     return CupertinoPageScaffold(
       backgroundColor: AppColors.focusCanvas,
       child: Stack(
         alignment: Alignment.center,
         children: [
-            Container(
-              width: 300,
-              height: 300,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: _glowColor.withOpacity(0.15),
-                boxShadow: [
-                  BoxShadow(
-                    color: _glowColor.withOpacity(0.3),
-                    blurRadius: 120,
-                    spreadRadius: 20,
+          _PulsingGlow(
+            color: _glowColor,
+            // The glow only breathes while actively counting down. Paused or
+            // finished it holds still — no wasted 60fps repaints, and it
+            // respects the system Reduce Motion setting.
+            active: isRunning && !completed && !reduceMotion,
+          ),
+          SafeArea(
+            child: Column(
+              children: [
+                Align(
+                  alignment: AlignmentDirectional.topStart,
+                  child: CupertinoButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Icon(
+                      CupertinoIcons.xmark,
+                      color: CupertinoColors.white,
+                      semanticLabel: 'بستن جلسه تمرکز',
+                    ),
                   ),
-                ],
-              ),
-            ).animate(onPlay: (c) => c.repeat(reverse: true)).scale(
-                  duration: 4.seconds,
-                  begin: const Offset(0.8, 0.8),
-                  end: const Offset(1.3, 1.3),
                 ),
-            SafeArea(
-              child: Column(
-                children: [
-                  Align(
-                    alignment: AlignmentDirectional.topStart,
-                    child: CupertinoButton(
-                      onPressed: () => Navigator.pop(context),
-                      child: const Icon(
-                        CupertinoIcons.xmark,
-                        color: CupertinoColors.white,
-                      ),
-                    ),
+                const Spacer(),
+                Hero(
+                  tag: 'play_${widget.task.id}',
+                  child: const SizedBox.shrink(),
+                ),
+                Text(
+                  widget.task.category,
+                  style: TextStyle(
+                    color: _glowColor,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 1,
                   ),
-                  const Spacer(),
-                  Hero(
-                    tag: 'play_${widget.task.id}',
-                    child: const SizedBox.shrink(),
-                  ),
-                  Text(
-                    widget.task.category,
-                    style: TextStyle(
-                      color: _glowColor,
+                ),
+                const SizedBox(height: 10),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxl),
+                  child: Text(
+                    widget.task.title,
+                    textAlign: TextAlign.center,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: CupertinoColors.white,
+                      fontSize: 26,
                       fontWeight: FontWeight.w700,
-                      letterSpacing: 1,
                     ),
                   ),
-                  const SizedBox(height: 10),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 32),
-                    child: Text(
-                      widget.task.title,
-                      textAlign: TextAlign.center,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: const TextStyle(
-                        color: CupertinoColors.white,
-                        fontSize: 26,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: 48),
-                  if (session.completed)
-                    _CompletionBadge(color: _glowColor)
-                  else
-                    Stack(
-                      alignment: Alignment.center,
-                      children: [
-                        CircularPercentIndicator(
-                          radius: 140,
-                          lineWidth: 6,
-                          percent: session.progress,
-                          backgroundColor: CupertinoColors.white.withOpacity(0.08),
-                          progressColor:
-                              remaining < 60 ? AppColors.accentRed : _glowColor,
-                          circularStrokeCap: CircularStrokeCap.round,
-                          animateFromLastPercent: true,
-                          animation: true,
-                          animationDuration: 900,
-                        ),
-                        Text('$minutes:$seconds', style: AppTypography.timer),
-                      ],
-                    ),
-                  const SizedBox(height: 48),
-                  if (session.completed)
-                    _DoneButton(onTap: () => Navigator.pop(context))
-                  else
-                    const _Controls(),
-                  const Spacer(flex: 2),
-                ],
-              ),
+                ),
+                const SizedBox(height: 48),
+                if (completed)
+                  _CompletionBadge(color: _glowColor, reduceMotion: reduceMotion)
+                else
+                  _TimerReadout(accent: _glowColor, reduceMotion: reduceMotion),
+                const SizedBox(height: 48),
+                if (completed)
+                  _DoneButton(onTap: () => Navigator.pop(context))
+                else
+                  const _Controls(),
+                const Spacer(flex: 2),
+              ],
             ),
-          ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Self-contained breathing glow. Owns its own controller so it is not
+/// rebuilt by the per-second timer tick, and starts/stops with [active].
+class _PulsingGlow extends StatefulWidget {
+  const _PulsingGlow({required this.color, required this.active});
+
+  final Color color;
+  final bool active;
+
+  @override
+  State<_PulsingGlow> createState() => _PulsingGlowState();
+}
+
+class _PulsingGlowState extends State<_PulsingGlow>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(seconds: 4),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _sync();
+  }
+
+  @override
+  void didUpdateWidget(_PulsingGlow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.active != oldWidget.active) _sync();
+  }
+
+  void _sync() {
+    if (widget.active) {
+      _controller.repeat(reverse: true);
+    } else {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: ScaleTransition(
+        scale: Tween<double>(begin: 0.85, end: 1.25).animate(
+          CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
         ),
+        child: Container(
+          width: 300,
+          height: 300,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: widget.color.withOpacity(0.15),
+            boxShadow: [
+              BoxShadow(
+                color: widget.color.withOpacity(0.3),
+                blurRadius: 120,
+                spreadRadius: 20,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The only part of the screen that rebuilds every second.
+class _TimerReadout extends ConsumerWidget {
+  const _TimerReadout({required this.accent, required this.reduceMotion});
+
+  final Color accent;
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final remaining =
+        ref.watch(focusTimerProvider.select((s) => s?.remainingSeconds ?? 0));
+    final progress =
+        ref.watch(focusTimerProvider.select((s) => s?.progress ?? 0.0));
+
+    final minutes = remaining ~/ 60;
+    final seconds = remaining % 60;
+
+    return Semantics(
+      label: 'زمان باقی‌مانده: $minutes دقیقه و $seconds ثانیه',
+      excludeSemantics: true,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CircularPercentIndicator(
+            radius: 140,
+            lineWidth: 6,
+            percent: progress.clamp(0.0, 1.0),
+            backgroundColor: CupertinoColors.white.withOpacity(0.08),
+            progressColor: remaining < 60 ? AppColors.accentRed : accent,
+            circularStrokeCap: CircularStrokeCap.round,
+            animateFromLastPercent: true,
+            animation: !reduceMotion,
+            animationDuration: 900,
+          ),
+          Text(Fmt.clock(remaining), style: AppTypography.timer),
+        ],
+      ),
     );
   }
 }
@@ -170,71 +259,98 @@ class _Controls extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final session = ref.watch(focusTimerProvider);
-    if (session == null) return const SizedBox.shrink();
+    final isRunning =
+        ref.watch(focusTimerProvider.select((s) => s?.isRunning ?? false));
     final notifier = ref.read(focusTimerProvider.notifier);
     final haptics = ref.read(hapticsServiceProvider);
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        _GlassStepButton(label: '-5', onTap: () => notifier.adjust(-300)),
-        const SizedBox(width: 32),
-        GestureDetector(
-          onTap: () {
-            haptics.light();
-            session.isRunning ? notifier.pause() : notifier.resume();
-          },
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(40),
-            child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-              child: Container(
-                width: 80,
-                height: 80,
-                decoration: BoxDecoration(
-                  color: CupertinoColors.white.withOpacity(0.16),
-                  shape: BoxShape.circle,
-                  border: Border.all(color: CupertinoColors.white.withOpacity(0.25)),
-                ),
-                child: Icon(
-                  session.isRunning
-                      ? CupertinoIcons.pause_fill
-                      : CupertinoIcons.play_fill,
-                  color: CupertinoColors.white,
-                  size: 32,
+        _GlassStepButton(
+          label: '−۵',
+          semanticLabel: 'کاهش پنج دقیقه',
+          onTap: () => notifier.adjust(-300),
+        ),
+        const SizedBox(width: AppSpacing.xxl),
+        Semantics(
+          button: true,
+          label: isRunning ? 'توقف موقت' : 'ادامه',
+          child: GestureDetector(
+            onTap: () {
+              haptics.light();
+              isRunning ? notifier.pause() : notifier.resume();
+            },
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(AppSpacing.minTouchTarget),
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                child: Container(
+                  width: 80,
+                  height: 80,
+                  decoration: BoxDecoration(
+                    color: CupertinoColors.white.withOpacity(0.16),
+                    shape: BoxShape.circle,
+                    border:
+                        Border.all(color: CupertinoColors.white.withOpacity(0.25)),
+                  ),
+                  child: Icon(
+                    isRunning
+                        ? CupertinoIcons.pause_fill
+                        : CupertinoIcons.play_fill,
+                    color: CupertinoColors.white,
+                    size: 32,
+                  ),
                 ),
               ),
             ),
           ),
         ),
-        const SizedBox(width: 32),
-        _GlassStepButton(label: '+5', onTap: () => notifier.adjust(300)),
+        const SizedBox(width: AppSpacing.xxl),
+        _GlassStepButton(
+          label: '+۵',
+          semanticLabel: 'افزودن پنج دقیقه',
+          onTap: () => notifier.adjust(300),
+        ),
       ],
     );
   }
 }
 
 class _GlassStepButton extends StatelessWidget {
-  const _GlassStepButton({required this.label, required this.onTap});
+  const _GlassStepButton({
+    required this.label,
+    required this.semanticLabel,
+    required this.onTap,
+  });
 
   final String label;
+  final String semanticLabel;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: LiquidGlass(
-        borderRadius: BorderRadius.circular(30),
-        blurSigma: 12,
-        onDark: true,
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-        child: Text(
-          label,
-          style: const TextStyle(
-            color: CupertinoColors.white,
-            fontWeight: FontWeight.w700,
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: LiquidGlass(
+          borderRadius: BorderRadius.circular(30),
+          blurSigma: 12,
+          onDark: true,
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.xl,
+            vertical: AppSpacing.md,
+          ),
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: CupertinoColors.white,
+              fontWeight: FontWeight.w700,
+              fontSize: 16,
+            ),
           ),
         ),
       ),
@@ -243,27 +359,36 @@ class _GlassStepButton extends StatelessWidget {
 }
 
 class _CompletionBadge extends StatelessWidget {
-  const _CompletionBadge({required this.color});
+  const _CompletionBadge({required this.color, required this.reduceMotion});
 
   final Color color;
+  final bool reduceMotion;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        Icon(CupertinoIcons.check_mark_circled_solid, color: color, size: 96)
-            .animate()
-            .scale(duration: 500.ms, curve: Curves.easeOutBack),
-        const SizedBox(height: 16),
-        const Text(
-          'تمام شد!',
-          style: TextStyle(
-            color: CupertinoColors.white,
-            fontSize: 22,
-            fontWeight: FontWeight.w700,
+    final icon = Icon(
+      CupertinoIcons.check_mark_circled_solid,
+      color: color,
+      size: 96,
+    );
+    return Semantics(
+      label: 'جلسه تمرکز کامل شد',
+      child: Column(
+        children: [
+          reduceMotion
+              ? icon
+              : icon.animate().scale(duration: 500.ms, curve: Curves.easeOutBack),
+          const SizedBox(height: AppSpacing.lg),
+          const Text(
+            'تمام شد!',
+            style: TextStyle(
+              color: CupertinoColors.white,
+              fontSize: 22,
+              fontWeight: FontWeight.w700,
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }
@@ -275,15 +400,26 @@ class _DoneButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: LiquidGlass(
-        borderRadius: BorderRadius.circular(30),
-        onDark: true,
-        padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 16),
-        child: const Text(
-          'بازگشت',
-          style: TextStyle(color: CupertinoColors.white, fontWeight: FontWeight.w700),
+    return Semantics(
+      button: true,
+      label: 'بازگشت',
+      excludeSemantics: true,
+      child: GestureDetector(
+        onTap: onTap,
+        child: LiquidGlass(
+          borderRadius: BorderRadius.circular(30),
+          onDark: true,
+          padding: const EdgeInsets.symmetric(
+            horizontal: 40,
+            vertical: AppSpacing.lg,
+          ),
+          child: const Text(
+            'بازگشت',
+            style: TextStyle(
+              color: CupertinoColors.white,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
         ),
       ),
     );

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_spacing.dart';
 import '../../core/theme/app_typography.dart';
 import '../../core/theme/liquid_glass.dart';
 import '../../providers/task_providers.dart';
@@ -21,17 +22,18 @@ class HomeScreen extends ConsumerWidget {
     final pinned = ref.watch(pinnedTasksProvider);
     final active = ref.watch(activeTasksProvider);
     final completed = ref.watch(completedTasksProvider);
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
 
     return LiquidCanvas(
       child: Stack(
         children: [
           tasksAsync.when(
             loading: () => const Center(child: CupertinoActivityIndicator()),
-            error: (error, _) => Center(
+            error: (error, _) => const Center(
               child: EmptyState(
                 icon: CupertinoIcons.exclamationmark_triangle,
                 title: 'مشکلی پیش اومد',
-                message: 'بارگذاری کارها با خطا مواجه شد.',
+                message: 'بارگذاری کارها با خطا مواجه شد. برای تلاش دوباره اپ را ببند و باز کن.',
               ),
             ),
             data: (allTasks) => CustomScrollView(
@@ -41,23 +43,26 @@ class HomeScreen extends ConsumerWidget {
                   delegate: MinimalHeader(),
                   pinned: true,
                 ),
-                const SliverToBoxAdapter(child: SizedBox(height: 10)),
+                const SliverToBoxAdapter(child: SizedBox(height: AppSpacing.sm)),
                 if (pinned.isNotEmpty)
                   SliverToBoxAdapter(
                     child: SizedBox(
                       height: 168,
                       child: ListView.separated(
                         scrollDirection: Axis.horizontal,
-                        padding: const EdgeInsets.symmetric(horizontal: 24),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppSpacing.gutter,
+                        ),
                         itemCount: pinned.length,
-                        separatorBuilder: (_, __) => const SizedBox(width: 12),
+                        separatorBuilder: (_, __) =>
+                            const SizedBox(width: AppSpacing.md),
                         itemBuilder: (_, i) => PinnedCard(task: pinned[i]),
                       ),
                     ),
                   ),
-                const SliverToBoxAdapter(child: SizedBox(height: 24)),
+                const SliverToBoxAdapter(child: SizedBox(height: AppSpacing.xl)),
                 if (allTasks.isEmpty)
-                  SliverFillRemaining(
+                  const SliverFillRemaining(
                     hasScrollBody: false,
                     child: Center(
                       child: EmptyState(
@@ -69,7 +74,9 @@ class HomeScreen extends ConsumerWidget {
                   )
                 else ...[
                   SliverPadding(
-                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.gutter,
+                    ),
                     sliver: SliverList(
                       delegate: SliverChildBuilderDelegate(
                         (_, i) => TaskTile(task: active[i]),
@@ -80,12 +87,22 @@ class HomeScreen extends ConsumerWidget {
                   if (completed.isNotEmpty)
                     SliverToBoxAdapter(
                       child: Padding(
-                        padding: const EdgeInsets.fromLTRB(24, 18, 24, 10),
-                        child: Text('انجام شده', style: AppTypography.caption),
+                        padding: const EdgeInsets.fromLTRB(
+                          AppSpacing.gutter,
+                          18,
+                          AppSpacing.gutter,
+                          AppSpacing.sm,
+                        ),
+                        child: Semantics(
+                          header: true,
+                          child: Text('انجام شده', style: AppTypography.caption),
+                        ),
                       ),
                     ),
                   SliverPadding(
-                    padding: const EdgeInsets.symmetric(horizontal: 24),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.gutter,
+                    ),
                     sliver: SliverList(
                       delegate: SliverChildBuilderDelegate(
                         (_, i) => TaskTile(task: completed[i], isDone: true),
@@ -101,27 +118,46 @@ class HomeScreen extends ConsumerWidget {
           Align(
             alignment: AlignmentDirectional.bottomCenter,
             child: Padding(
-              padding: const EdgeInsets.only(bottom: 28),
-              child: LiquidGlassTap(
-                onTap: () => openTaskSheet(context),
-                borderRadius: BorderRadius.circular(32),
-                blurSigma: 24,
-                tint: AppColors.ink,
-                tintOpacity: 0.85,
-                padding: const EdgeInsets.all(18),
-                child: const Icon(
-                  CupertinoIcons.add,
-                  color: CupertinoColors.white,
-                  size: 30,
-                ),
-              ).animate().scale(
-                    duration: 420.ms,
-                    curve: Curves.easeOutBack,
-                  ),
+              // Respect the home-indicator / gesture inset so the button never
+              // sits under the system UI on modern iPhones.
+              padding: EdgeInsets.only(
+                bottom: 20 + MediaQuery.of(context).padding.bottom,
+              ),
+              child: _AddButton(reduceMotion: reduceMotion),
             ),
           ),
         ],
       ),
     );
+  }
+}
+
+class _AddButton extends StatelessWidget {
+  const _AddButton({required this.reduceMotion});
+
+  final bool reduceMotion;
+
+  @override
+  Widget build(BuildContext context) {
+    final button = Semantics(
+      button: true,
+      label: 'افزودن کار جدید',
+      child: LiquidGlassTap(
+        onTap: () => openTaskSheet(context),
+        borderRadius: BorderRadius.circular(AppRadius.sheet),
+        blurSigma: 24,
+        tint: AppColors.ink,
+        tintOpacity: 0.85,
+        padding: const EdgeInsets.all(18),
+        child: const Icon(
+          CupertinoIcons.add,
+          color: CupertinoColors.white,
+          size: 30,
+        ),
+      ),
+    );
+
+    if (reduceMotion) return button;
+    return button.animate().scale(duration: 420.ms, curve: Curves.easeOutBack);
   }
 }

--- a/lib/presentation/widgets/empty_state.dart
+++ b/lib/presentation/widgets/empty_state.dart
@@ -18,28 +18,34 @@ class EmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
+    final content = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 48),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 44, color: AppColors.inkSubdued.withOpacity(0.5)),
-          const SizedBox(height: 16),
-          Text(
-            title,
-            textAlign: TextAlign.center,
-            style: AppTypography.title.copyWith(color: AppColors.inkSubdued),
-          ),
-          const SizedBox(height: 6),
-          Text(
-            message,
-            textAlign: TextAlign.center,
-            maxLines: 3,
-            overflow: TextOverflow.ellipsis,
-            style: AppTypography.caption,
-          ),
-        ],
+      child: Semantics(
+        container: true,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 44, color: AppColors.inkSubdued.withOpacity(0.5)),
+            const SizedBox(height: 16),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: AppTypography.title.copyWith(color: AppColors.inkSubdued),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.caption,
+            ),
+          ],
+        ),
       ),
-    ).animate().fadeIn(duration: 400.ms).slideY(begin: 0.05, end: 0);
+    );
+
+    if (MediaQuery.of(context).disableAnimations) return content;
+    return content.animate().fadeIn(duration: 400.ms).slideY(begin: 0.05, end: 0);
   }
 }

--- a/lib/presentation/widgets/pinned_card.dart
+++ b/lib/presentation/widgets/pinned_card.dart
@@ -2,11 +2,14 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_spacing.dart';
 import '../../core/theme/app_typography.dart';
 import '../../core/theme/liquid_glass.dart';
+import '../../core/utils/formatting.dart';
 import '../../data/models/task.dart';
 import '../../providers/task_providers.dart';
 import '../navigation.dart';
+import 'tappable_icon.dart';
 
 class PinnedCard extends ConsumerWidget {
   const PinnedCard({super.key, required this.task});
@@ -19,8 +22,8 @@ class PinnedCard extends ConsumerWidget {
       width: 156,
       child: LiquidGlassTap(
         onTap: () => openTaskSheet(context, task),
-        borderRadius: BorderRadius.circular(24),
-        padding: const EdgeInsets.all(16),
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        padding: const EdgeInsets.all(AppSpacing.lg),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -28,17 +31,30 @@ class PinnedCard extends ConsumerWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                GestureDetector(
-                  onTap: () =>
-                      ref.read(tasksProvider.notifier).toggleComplete(task.id),
-                  child: Container(
-                    width: 22,
-                    height: 22,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      border: Border.all(
-                        color: CupertinoColors.white.withOpacity(0.7),
-                        width: 2,
+                Semantics(
+                  button: true,
+                  checked: false,
+                  label: 'علامت‌گذاری به‌عنوان انجام‌شده',
+                  excludeSemantics: true,
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: () =>
+                        ref.read(tasksProvider.notifier).toggleComplete(task.id),
+                    child: SizedBox(
+                      width: 36,
+                      height: 36,
+                      child: Center(
+                        child: Container(
+                          width: 22,
+                          height: 22,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: CupertinoColors.white.withOpacity(0.7),
+                              width: 2,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -61,21 +77,21 @@ class PinnedCard extends ConsumerWidget {
               children: [
                 Flexible(
                   child: Text(
-                    '${task.duration} دقیقه',
+                    Fmt.fa('${task.duration} دقیقه'),
                     overflow: TextOverflow.ellipsis,
                     style: AppTypography.caption,
                   ),
                 ),
-                const SizedBox(width: 6),
+                const SizedBox(width: AppSpacing.xs),
                 Hero(
                   tag: 'play_${task.id}',
-                  child: GestureDetector(
+                  child: TappableIcon(
+                    icon: CupertinoIcons.play_circle_fill,
+                    size: 26,
+                    color: AppColors.ink,
+                    minTarget: 36,
+                    semanticLabel: 'شروع تمرکز روی ${task.title}',
                     onTap: () => openFocusPage(context, task),
-                    child: const Icon(
-                      CupertinoIcons.play_circle_fill,
-                      size: 26,
-                      color: AppColors.ink,
-                    ),
                   ),
                 ),
               ],

--- a/lib/presentation/widgets/tappable_icon.dart
+++ b/lib/presentation/widgets/tappable_icon.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/cupertino.dart';
+
+import '../../core/theme/app_spacing.dart';
+
+/// An icon button that always meets Apple's 44pt minimum touch target and
+/// always carries a VoiceOver label — the two things every bare
+/// `GestureDetector(child: Icon(...))` in this app was missing.
+///
+/// The visible icon stays its natural [size]; the tappable/hit area is padded
+/// out to at least [AppSpacing.minTouchTarget] without affecting layout size
+/// beyond that.
+class TappableIcon extends StatelessWidget {
+  const TappableIcon({
+    super.key,
+    required this.icon,
+    required this.onTap,
+    required this.semanticLabel,
+    this.color,
+    this.size = 24,
+    this.minTarget = AppSpacing.minTouchTarget,
+  });
+
+  final IconData icon;
+  final VoidCallback onTap;
+
+  /// Spoken by VoiceOver. Describes the action, not the glyph
+  /// (e.g. "علامت‌گذاری به‌عنوان انجام‌شده", not "دایره").
+  final String semanticLabel;
+
+  final Color? color;
+  final double size;
+  final double minTarget;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      container: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(minWidth: minTarget, minHeight: minTarget),
+          child: Center(
+            widthFactor: 1,
+            heightFactor: 1,
+            child: Icon(icon, size: size, color: color),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/task_form.dart
+++ b/lib/presentation/widgets/task_form.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_typography.dart';
+import '../../core/utils/formatting.dart';
 import '../../data/models/sub_task.dart';
 import '../../data/models/task.dart';
 import '../../providers/task_providers.dart';
@@ -34,6 +35,9 @@ class _TaskFormState extends ConsumerState<TaskForm> {
     super.initState();
     final t = widget.task;
     _titleController = TextEditingController(text: t?.title ?? '');
+    // Rebuild on text change so the Save button reflects whether there's a
+    // non-empty title, instead of silently no-op'ing on an empty save.
+    _titleController.addListener(_onTitleChanged);
     if (t != null) {
       _category = t.category;
       _duration = t.duration;
@@ -43,8 +47,13 @@ class _TaskFormState extends ConsumerState<TaskForm> {
     }
   }
 
+  void _onTitleChanged() => setState(() {});
+
+  bool get _canSave => _titleController.text.trim().isNotEmpty;
+
   @override
   void dispose() {
+    _titleController.removeListener(_onTitleChanged);
     _titleController.dispose();
     super.dispose();
   }
@@ -125,7 +134,7 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                       ),
                       const SizedBox(width: 8),
                       GlassBadge(
-                        '$_duration دقیقه',
+                        Fmt.fa('$_duration دقیقه'),
                         icon: CupertinoIcons.timer,
                         onTap: () => setState(() {
                           final i = _durations.indexOf(_duration);
@@ -141,13 +150,21 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                       ),
                       const SizedBox(width: 8),
                       GlassBadge(
-                        _reminder != null
-                            ? '${_reminder!.hour}:${_reminder!.minute.toString().padLeft(2, '0')}'
-                            : 'یادآور',
-                        icon: CupertinoIcons.alarm,
+                        _reminder != null ? Fmt.timeOfDay(_reminder!) : 'یادآور',
+                        icon: _reminder != null
+                            ? CupertinoIcons.alarm_fill
+                            : CupertinoIcons.alarm,
                         active: _reminder != null,
                         onTap: _pickReminderTime,
                       ),
+                      if (_reminder != null) ...[
+                        const SizedBox(width: 8),
+                        GlassBadge(
+                          'حذف یادآور',
+                          icon: CupertinoIcons.xmark,
+                          onTap: () => setState(() => _reminder = null),
+                        ),
+                      ],
                     ],
                   ),
                 ),
@@ -156,7 +173,9 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      'زیرمجموعه (${_subtasks.where((e) => e.isCompleted).length}/${_subtasks.length})',
+                      Fmt.fa(
+                        'زیرمجموعه (${_subtasks.where((e) => e.isCompleted).length}/${_subtasks.length})',
+                      ),
                       style: AppTypography.caption,
                     ),
                     CupertinoButton(
@@ -229,8 +248,11 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                 const SizedBox(height: 24),
                 CupertinoButton(
                   color: AppColors.ink,
+                  disabledColor: AppColors.ink.withOpacity(0.3),
                   borderRadius: BorderRadius.circular(16),
-                  onPressed: _save,
+                  // Disabled (not silently no-op) until there's a title, so the
+                  // button's state always matches what tapping it will do.
+                  onPressed: _canSave ? _save : null,
                   child: const Text(
                     'ذخیره',
                     style: TextStyle(
@@ -277,24 +299,72 @@ class _TaskFormState extends ConsumerState<TaskForm> {
     );
   }
 
+  /// Builds a reminder for [hour]:[minute] today, or tomorrow if that moment
+  /// has already passed — so "remind me at 8:00" never silently drops because
+  /// 8:00 was earlier today.
+  DateTime _nextOccurrence(int hour, int minute) {
+    final now = DateTime.now();
+    var candidate = DateTime(now.year, now.month, now.day, hour, minute);
+    if (!candidate.isAfter(now)) {
+      candidate = candidate.add(const Duration(days: 1));
+    }
+    return candidate;
+  }
+
   Future<void> _pickReminderTime() async {
     final granted = await ensureNotificationPermission(context, ref);
     if (!granted || !mounted) return;
 
+    // Seed the picker with the current selection (or now) and only commit on
+    // "تایید", so scrolling the wheel doesn't thrash setState every frame.
+    final initial = _reminder ?? DateTime.now();
+    var pending = _nextOccurrence(initial.hour, initial.minute);
+
     await showCupertinoModalPopup<void>(
       context: context,
       builder: (popupContext) => Container(
-        height: 250,
+        height: 300,
         color: CupertinoColors.systemBackground.resolveFrom(popupContext),
-        child: CupertinoDatePicker(
-          mode: CupertinoDatePickerMode.time,
-          use24hFormat: true,
-          onDateTimeChanged: (t) {
-            final now = DateTime.now();
-            setState(
-              () => _reminder = DateTime(now.year, now.month, now.day, t.hour, t.minute),
-            );
-          },
+        child: SafeArea(
+          top: false,
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    CupertinoButton(
+                      onPressed: () {
+                        setState(() => _reminder = null);
+                        Navigator.pop(popupContext);
+                      },
+                      child: const Text(
+                        'حذف',
+                        style: TextStyle(color: AppColors.accentRed),
+                      ),
+                    ),
+                    CupertinoButton(
+                      onPressed: () {
+                        setState(() => _reminder = pending);
+                        Navigator.pop(popupContext);
+                      },
+                      child: const Text('تایید'),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.time,
+                  use24hFormat: true,
+                  initialDateTime: initial,
+                  onDateTimeChanged: (t) =>
+                      pending = _nextOccurrence(t.hour, t.minute),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/widgets/task_tile.dart
+++ b/lib/presentation/widgets/task_tile.dart
@@ -2,11 +2,14 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_spacing.dart';
 import '../../core/theme/app_typography.dart';
 import '../../core/theme/liquid_glass.dart';
+import '../../core/utils/formatting.dart';
 import '../../data/models/task.dart';
 import '../../providers/task_providers.dart';
 import '../navigation.dart';
+import 'tappable_icon.dart';
 
 class TaskTile extends ConsumerStatefulWidget {
   const TaskTile({super.key, required this.task, this.isDone = false});
@@ -24,49 +27,28 @@ class _TaskTileState extends ConsumerState<TaskTile> {
   @override
   Widget build(BuildContext context) {
     final task = widget.task;
+    final hasSubtasks = task.subtasks.isNotEmpty;
 
     return Padding(
-      padding: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: Column(
         children: [
           LiquidGlassTap(
             onTap: () => openTaskSheet(context, task),
-            onLongPress: task.subtasks.isEmpty
-                ? null
-                : () => setState(() => _expanded = !_expanded),
-            borderRadius: BorderRadius.circular(24),
-            padding: const EdgeInsets.all(16),
+            onLongPress:
+                hasSubtasks ? () => setState(() => _expanded = !_expanded) : null,
+            borderRadius: BorderRadius.circular(AppRadius.lg),
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.md,
+              vertical: AppSpacing.sm,
+            ),
             child: Row(
               children: [
-                GestureDetector(
+                _Checkbox(
+                  isDone: widget.isDone,
                   onTap: () =>
                       ref.read(tasksProvider.notifier).toggleComplete(task.id),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 200),
-                    width: 26,
-                    height: 26,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: widget.isDone
-                          ? AppColors.accentGreen
-                          : CupertinoColors.transparent,
-                      border: Border.all(
-                        color: widget.isDone
-                            ? AppColors.accentGreen
-                            : CupertinoColors.white.withOpacity(0.7),
-                        width: 2,
-                      ),
-                    ),
-                    child: widget.isDone
-                        ? const Icon(
-                            CupertinoIcons.check_mark,
-                            size: 14,
-                            color: CupertinoColors.white,
-                          )
-                        : null,
-                  ),
                 ),
-                const SizedBox(width: 14),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -84,104 +66,154 @@ class _TaskTileState extends ConsumerState<TaskTile> {
                               : AppColors.ink,
                         ),
                       ),
-                      if (!widget.isDone)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 4),
-                          child: Row(
-                            children: [
-                              Flexible(
-                                child: Text(
-                                  task.category,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: AppTypography.caption,
-                                ),
-                              ),
-                              if (task.reminder != null) ...[
-                                const SizedBox(width: 8),
-                                Icon(
-                                  CupertinoIcons.alarm,
-                                  size: 12,
-                                  color: AppColors.inkSubdued,
-                                ),
-                                Text(
-                                  ' ${task.reminder!.hour}:${task.reminder!.minute.toString().padLeft(2, '0')}',
-                                  style: AppTypography.caption,
-                                ),
-                              ],
-                              if (task.subtasks.isNotEmpty) ...[
-                                const SizedBox(width: 8),
-                                Icon(
-                                  CupertinoIcons.list_bullet,
-                                  size: 12,
-                                  color: AppColors.inkSubdued,
-                                ),
-                                Text(
-                                  ' ${task.subtasks.where((e) => e.isCompleted).length}/${task.subtasks.length}',
-                                  style: AppTypography.caption,
-                                ),
-                              ],
-                            ],
-                          ),
-                        ),
+                      if (!widget.isDone) _MetaRow(task: task),
                     ],
                   ),
                 ),
-                if (!widget.isDone) ...[
-                  const SizedBox(width: 8),
+                if (!widget.isDone)
                   Hero(
                     tag: 'play_${task.id}',
-                    child: GestureDetector(
+                    child: TappableIcon(
+                      icon: CupertinoIcons.play_circle_fill,
+                      size: 30,
+                      color: AppColors.ink,
+                      semanticLabel: 'شروع تمرکز روی ${task.title}',
                       onTap: () => openFocusPage(context, task),
-                      child: const Icon(
-                        CupertinoIcons.play_circle_fill,
-                        size: 30,
-                        color: AppColors.ink,
-                      ),
                     ),
                   ),
-                ],
               ],
             ),
           ),
-          if (_expanded && task.subtasks.isNotEmpty)
+          if (_expanded && hasSubtasks)
             Padding(
-              padding: const EdgeInsets.only(top: 8),
+              padding: const EdgeInsets.only(top: AppSpacing.sm),
               child: LiquidGlass(
-                borderRadius: BorderRadius.circular(20),
+                borderRadius: BorderRadius.circular(AppRadius.md),
                 blurSigma: 18,
                 child: Column(
-                  children: task.subtasks
-                      .map(
-                        (s) => CupertinoListTile(
-                          leading: Icon(
-                            s.isCompleted
-                                ? CupertinoIcons.check_mark_circled_solid
-                                : CupertinoIcons.circle,
-                            color: s.isCompleted
-                                ? AppColors.accentGreen
-                                : AppColors.inkSubdued,
-                            size: 18,
-                          ),
-                          title: Text(
-                            s.title,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              decoration: s.isCompleted
-                                  ? TextDecoration.lineThrough
-                                  : null,
-                              fontSize: 13,
-                            ),
-                          ),
-                          onTap: () => ref
-                              .read(tasksProvider.notifier)
-                              .toggleSubTask(task.id, s.id),
+                  children: [
+                    for (final s in task.subtasks)
+                      CupertinoListTile(
+                        leading: Icon(
+                          s.isCompleted
+                              ? CupertinoIcons.check_mark_circled_solid
+                              : CupertinoIcons.circle,
+                          color: s.isCompleted
+                              ? AppColors.accentGreen
+                              : AppColors.inkSubdued,
+                          size: 18,
                         ),
-                      )
-                      .toList(),
+                        title: Text(
+                          s.title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            decoration: s.isCompleted
+                                ? TextDecoration.lineThrough
+                                : null,
+                            fontSize: 13,
+                          ),
+                        ),
+                        onTap: () => ref
+                            .read(tasksProvider.notifier)
+                            .toggleSubTask(task.id, s.id),
+                      ),
+                  ],
                 ),
               ),
             ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Checkbox extends StatelessWidget {
+  const _Checkbox({required this.isDone, required this.onTap});
+
+  final bool isDone;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      checked: isDone,
+      label: isDone ? 'انجام‌شده — لغو تکمیل' : 'علامت‌گذاری به‌عنوان انجام‌شده',
+      excludeSemantics: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          width: AppSpacing.minTouchTarget,
+          height: AppSpacing.minTouchTarget,
+          child: Center(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: 26,
+              height: 26,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color:
+                    isDone ? AppColors.accentGreen : CupertinoColors.transparent,
+                border: Border.all(
+                  color: isDone
+                      ? AppColors.accentGreen
+                      : CupertinoColors.white.withOpacity(0.7),
+                  width: 2,
+                ),
+              ),
+              child: isDone
+                  ? const Icon(
+                      CupertinoIcons.check_mark,
+                      size: 14,
+                      color: CupertinoColors.white,
+                    )
+                  : null,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MetaRow extends StatelessWidget {
+  const _MetaRow({required this.task});
+
+  final Task task;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.xs),
+      child: Row(
+        children: [
+          Flexible(
+            child: Text(
+              task.category,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.caption,
+            ),
+          ),
+          if (task.reminder != null) ...[
+            const SizedBox(width: AppSpacing.sm),
+            const Icon(CupertinoIcons.alarm, size: 12, color: AppColors.inkSubdued),
+            const SizedBox(width: 2),
+            Text(Fmt.timeOfDay(task.reminder!), style: AppTypography.caption),
+          ],
+          if (task.subtasks.isNotEmpty) ...[
+            const SizedBox(width: AppSpacing.sm),
+            const Icon(CupertinoIcons.list_bullet,
+                size: 12, color: AppColors.inkSubdued),
+            const SizedBox(width: 2),
+            Text(
+              Fmt.fa(
+                '${task.subtasks.where((e) => e.isCompleted).length}/${task.subtasks.length}',
+              ),
+              style: AppTypography.caption,
+            ),
+          ],
         ],
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: app
 description: "Nava - A minimalist productivity app inspired by Jony Ive."
 publish_to: 'none'
-version: 1.1.0+2
+version: 1.1.0+3
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
A production-quality refinement pass reviewing the whole app (not just recent changes) against Apple HIG, accessibility, motion, and performance standards. Brutally honest findings and fixes below.

## What was found & fixed

### 🦻 Accessibility — the headline finding: the app had **zero** accessibility instrumentation
- **No VoiceOver labels** on any icon-only control. → Added a reusable `TappableIcon` and `Semantics` roles/labels to play buttons, checkboxes (with `checked` state), timer controls, step buttons, and the FAB.
- **Touch targets below Apple's 44pt minimum** (26pt checkbox, 22pt pinned-card checkbox, 20pt subtask icons). → `TappableIcon` and enlarged hit areas guarantee ≥44/36pt without changing the visual size.
- **No Dynamic Type support** — fixed font sizes ignored the system text-size setting. → Global `textScaler` honoring the system setting, clamped to `[0.9, 1.35]` so large sizes scale without shattering the fixed-height glass layouts.
- **No Reduce Motion support.** → The focus glow, completion bounce, FAB entrance, progress-ring animation, and empty-state entrance all fall back to static when Reduce Motion is on.

### ⚡ Motion & battery
- The focus-screen glow was an **infinite 60fps repaint that ran even while paused or completed** — a real battery drain. → Rebuilt as a self-contained `AnimationController` that only animates while actively counting down (and is skipped under Reduce Motion).
- The per-second timer tick rebuilt the **entire** focus page (glow + controls + chrome). → Scoped the tick to a small readout subtree via Riverpod `.select`, so only the digits + ring repaint each second.

### 🧭 UX fixes
- **Reminders couldn't be cleared** once set. → Added a "حذف" action in the picker plus a clear chip.
- A reminder set for a **time already past today was silently dropped** on save. → Now rolls to tomorrow (`_nextOccurrence`).
- **Save silently no-op'd** on an empty title. → Button is now visibly disabled until there's a title.
- The reminder picker thrashed `setState` on every wheel frame. → Commits only on confirm.

### 🎨 Consistency & tokens
- **Latin digits inside an otherwise Persian RTL UI** (timer, durations, reminder times, counts). → Persian numerals everywhere via a `Fmt` helper.
- Scattered magic-number spacing/radii. → New `AppSpacing` / `AppRadius` token files.
- Notification-init failure could **block app launch**. → Now caught and degraded gracefully.

## Per the review template
1–4. See findings above (what/why/how/why-better).
5. **Remaining improvements** (not done here, deliberately scoped): category/duration chips cycle-on-tap isn't discoverable (a picker would be better); no light/dark theme split yet (canvas is light-only); focus completion doesn't offer to mark the task done; no unit/widget tests beyond the smoke test; `withOpacity` could migrate to `withValues` on newer Flutter.
6. **Risk**: Low-to-moderate. Changes are additive/structural; the focus-page glow was rewritten (behavior preserved). Main risk is that **I could not compile** (no Flutter SDK in the environment) — verified by bracket balance, import/usage, and type-checking by hand.
7. **Performance impact**: Positive — fewer per-second rebuilds, glow stops when idle.
8. **UX impact**: Positive — accessible to VoiceOver/Dynamic Type/Reduce Motion users, clearable reminders, no silent failures.
9. **Product impact**: Moves the app from "looks nice" toward "shippable to accessibility-conscious users / App Store review."
10. **Tech debt removed**: magic numbers, unlabeled controls, an always-on animation, silent-failure paths.

## ⚠️ Must do before merge
No Flutter/Dart SDK is available in this environment, so this was **not compiled**. Please run:
```
flutter pub get && flutter analyze && flutter test
```
Watch specifically for: `TextScaler.clamp` (needs Flutter ≥3.16 — fine on the 3.19+ target), and the `.select` usages in `focus_page.dart`.


---
_Generated by [Claude Code](https://claude.ai/code/session_018z6ocUcTxrFsXjzhJsiR1C)_