### PR TITLE
Harden release workflow: sanitize + validate version input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,22 @@ jobs:
 
       - name: Resolve version
         id: version
+        env:
+          RAW_VERSION: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || github.ref_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "version=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          # Sanitize: trim surrounding whitespace and any stray trailing dot,
+          # then require a clean vX.Y.Z shape. Prevents malformed release
+          # titles / asset names like "Nava-v1.1.0 -..." from a fat-fingered
+          # input, and reads the value via env (not string interpolation) so a
+          # crafted input can't inject shell.
+          version="$(printf '%s' "$RAW_VERSION" | tr -d '[:space:]')"
+          version="${version%.}"
+          if ! printf '%s' "$version" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+            echo "::error::Invalid version '$RAW_VERSION'. Expected vMAJOR.MINOR.PATCH (e.g. v1.2.0)."
+            exit 1
           fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $version"
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Context
The v1.1.0 release build **succeeded** and the arm64-v8a APK is published. While verifying it, I found a real defect in the release workflow that had already produced visible artifacts on the release.

## Problem
The `version` input was passed straight into the tag name, release title, and APK filename with no sanitization. A value entered with trailing whitespace or a stray dot produced malformed output — the live v1.1.0 release ended up with:
- Title `🍎 Nava v1.1.0 ` (trailing space)
- A duplicate/misnamed asset `Nava-v1.1.0.-android-arm64.apk` alongside the clean `Nava-v1.1.0-android-arm64.apk`

## Fix
`Resolve version` now:
- Reads the input via an **env var** instead of `${{ }}` string interpolation (removes a shell-injection surface).
- **Trims** all whitespace and strips a stray trailing dot.
- **Validates** the result against `vMAJOR.MINOR.PATCH` (optionally `-suffix`) and fails fast with a clear error otherwise.

## Not fixable via API (needs your one manual touch)
The GitHub MCP toolset has no "delete release asset" / "edit release" operation, so the **already-published** v1.1.0 needs a quick manual cleanup on the release page:
1. Delete the stray asset `Nava-v1.1.0.-android-arm64.apk` (keep `Nava-v1.1.0-android-arm64.apk`).
2. Edit the release title to `🍎 Nava v1.1.0` (remove the trailing space).

Both APKs are the same working build; this is purely cosmetic tidy-up. All **future** releases are protected by this PR.

## Verification
YAML validated. The regex/trim logic is standard POSIX shell; CI will exercise the workflow parse on merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_018z6ocUcTxrFsXjzhJsiR1C)_