### PR TITLE
v2.0.0 "Momentum": behavioral-science engagement layer

### DIFF
--- a/lib/data/models/focus_stats.dart
+++ b/lib/data/models/focus_stats.dart
@@ -1,0 +1,109 @@
+/// Persisted momentum data behind the behavioral-science features.
+///
+/// Stores only raw facts; "today's" derived values (which depend on the
+/// current date) are computed in [FocusStatsView] so the stored data never
+/// goes stale between days.
+class FocusStats {
+  const FocusStats({
+    this.totalSessions = 0,
+    this.sessionsOnLastDay = 0,
+    this.streak = 0,
+    this.longestStreak = 0,
+    this.lastSessionDay,
+    this.dailyGoal = 3,
+  });
+
+  /// Lifetime completed focus sessions.
+  final int totalSessions;
+
+  /// Sessions completed on [lastSessionDay] specifically.
+  final int sessionsOnLastDay;
+
+  /// Consecutive days (ending on [lastSessionDay]) with at least one session.
+  final int streak;
+
+  final int longestStreak;
+
+  /// Day-key ("y-m-d") of the most recent completed session, or null if none.
+  final String? lastSessionDay;
+
+  /// User's target sessions per day (goal-gradient target).
+  final int dailyGoal;
+
+  FocusStats copyWith({
+    int? totalSessions,
+    int? sessionsOnLastDay,
+    int? streak,
+    int? longestStreak,
+    String? lastSessionDay,
+    int? dailyGoal,
+  }) {
+    return FocusStats(
+      totalSessions: totalSessions ?? this.totalSessions,
+      sessionsOnLastDay: sessionsOnLastDay ?? this.sessionsOnLastDay,
+      streak: streak ?? this.streak,
+      longestStreak: longestStreak ?? this.longestStreak,
+      lastSessionDay: lastSessionDay ?? this.lastSessionDay,
+      dailyGoal: dailyGoal ?? this.dailyGoal,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'totalSessions': totalSessions,
+        'sessionsOnLastDay': sessionsOnLastDay,
+        'streak': streak,
+        'longestStreak': longestStreak,
+        'lastSessionDay': lastSessionDay,
+        'dailyGoal': dailyGoal,
+      };
+
+  factory FocusStats.fromJson(Map<String, dynamic> json) => FocusStats(
+        totalSessions: json['totalSessions'] as int? ?? 0,
+        sessionsOnLastDay: json['sessionsOnLastDay'] as int? ?? 0,
+        streak: json['streak'] as int? ?? 0,
+        longestStreak: json['longestStreak'] as int? ?? 0,
+        lastSessionDay: json['lastSessionDay'] as String?,
+        dailyGoal: json['dailyGoal'] as int? ?? 3,
+      );
+}
+
+/// A date-resolved read of [FocusStats]: the values the UI should actually
+/// show *today*. Keeping this separate from the stored model means a streak
+/// silently expires when a day is missed, without needing a write.
+class FocusStatsView {
+  FocusStatsView(this._stats, DateTime now)
+      : _today = _dayKey(now),
+        _yesterday = _dayKey(now.subtract(const Duration(days: 1)));
+
+  final FocusStats _stats;
+  final String _today;
+  final String _yesterday;
+
+  int get dailyGoal => _stats.dailyGoal;
+  int get longestStreak => _stats.longestStreak;
+  int get totalSessions => _stats.totalSessions;
+
+  /// Sessions completed *today* — zero on a fresh day even though the stored
+  /// `sessionsOnLastDay` still reflects the last active day.
+  int get sessionsToday =>
+      _stats.lastSessionDay == _today ? _stats.sessionsOnLastDay : 0;
+
+  /// The streak only "counts" if the last session was today or yesterday;
+  /// otherwise the chain is broken and shows as zero.
+  int get streak {
+    if (_stats.lastSessionDay == _today || _stats.lastSessionDay == _yesterday) {
+      return _stats.streak;
+    }
+    return 0;
+  }
+
+  /// 0..1 progress toward the daily goal (goal-gradient signal).
+  double get goalProgress {
+    if (dailyGoal <= 0) return 0;
+    return (sessionsToday / dailyGoal).clamp(0.0, 1.0);
+  }
+
+  bool get goalReached => sessionsToday >= dailyGoal;
+
+  static String _dayKey(DateTime d) => '${d.year}-${d.month}-${d.day}';
+}

--- a/lib/data/repositories/stats_repository.dart
+++ b/lib/data/repositories/stats_repository.dart
@@ -1,0 +1,28 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/focus_stats.dart';
+
+abstract class StatsRepository {
+  Future<FocusStats> load();
+  Future<void> save(FocusStats stats);
+}
+
+class SharedPreferencesStatsRepository implements StatsRepository {
+  static const _storageKey = 'nava_focus_stats_v1';
+
+  @override
+  Future<FocusStats> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_storageKey);
+    if (raw == null) return const FocusStats();
+    return FocusStats.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  }
+
+  @override
+  Future<void> save(FocusStats stats) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, jsonEncode(stats.toJson()));
+  }
+}

--- a/lib/presentation/screens/focus_page.dart
+++ b/lib/presentation/screens/focus_page.dart
@@ -128,7 +128,7 @@ class _FocusPageState extends ConsumerState<FocusPage> with WidgetsBindingObserv
                   _TimerReadout(accent: _glowColor, reduceMotion: reduceMotion),
                 const SizedBox(height: 48),
                 if (completed)
-                  _DoneButton(onTap: () => Navigator.pop(context))
+                  _CompletionActions(task: widget.task)
                 else
                   const _Controls(),
                 const Spacer(flex: 2),
@@ -393,32 +393,90 @@ class _CompletionBadge extends StatelessWidget {
   }
 }
 
-class _DoneButton extends StatelessWidget {
-  const _DoneButton({required this.onTap});
+/// Post-session actions. Closes the open loop (Zeigarnik) by offering to mark
+/// the task done, and nudges a short recovery break (ultradian rhythm).
+class _CompletionActions extends ConsumerWidget {
+  const _CompletionActions({required this.task});
 
+  final Task task;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isTaskDone = ref.watch(
+      tasksProvider.select((async) {
+        final list = async.valueOrNull;
+        if (list == null) return true;
+        for (final t in list) {
+          if (t.id == task.id) return t.isCompleted;
+        }
+        return true; // task no longer exists → nothing to complete
+      }),
+    );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Padding(
+          padding: EdgeInsets.symmetric(horizontal: AppSpacing.xxl),
+          child: Text(
+            'کمی استراحت کن ☕ چند دقیقه چشم‌ت رو از صفحه بردار.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: CupertinoColors.systemGrey, fontSize: 14),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xl),
+        if (!isTaskDone)
+          _CompletionButton(
+            label: 'کار انجام شد ✓',
+            filled: true,
+            onTap: () {
+              ref.read(tasksProvider.notifier).toggleComplete(task.id);
+              Navigator.pop(context);
+            },
+          ),
+        if (!isTaskDone) const SizedBox(height: AppSpacing.md),
+        _CompletionButton(
+          label: 'بازگشت',
+          filled: false,
+          onTap: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}
+
+class _CompletionButton extends StatelessWidget {
+  const _CompletionButton({
+    required this.label,
+    required this.filled,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool filled;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
-      label: 'بازگشت',
+      label: label,
       excludeSemantics: true,
-      child: GestureDetector(
-        onTap: onTap,
-        child: LiquidGlass(
-          borderRadius: BorderRadius.circular(30),
-          onDark: true,
-          padding: const EdgeInsets.symmetric(
-            horizontal: 40,
-            vertical: AppSpacing.lg,
-          ),
-          child: const Text(
-            'بازگشت',
-            style: TextStyle(
-              color: CupertinoColors.white,
-              fontWeight: FontWeight.w700,
-            ),
+      child: CupertinoButton(
+        color: filled
+            ? AppColors.accentGreen
+            : CupertinoColors.white.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(30),
+        padding: const EdgeInsets.symmetric(
+          horizontal: 40,
+          vertical: AppSpacing.md,
+        ),
+        onPressed: onTap,
+        child: Text(
+          label,
+          style: const TextStyle(
+            color: CupertinoColors.white,
+            fontWeight: FontWeight.w700,
           ),
         ),
       ),

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -10,6 +10,7 @@ import '../../providers/task_providers.dart';
 import '../navigation.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/minimal_header.dart';
+import '../widgets/momentum_card.dart';
 import '../widgets/pinned_card.dart';
 import '../widgets/task_tile.dart';
 
@@ -44,6 +45,16 @@ class HomeScreen extends ConsumerWidget {
                   pinned: true,
                 ),
                 const SliverToBoxAdapter(child: SizedBox(height: AppSpacing.sm)),
+                // Momentum summary (streak + daily goal) sits above the list
+                // once the user has any tasks, so the first thing they see is
+                // their progress, not an empty scoreboard.
+                if (allTasks.isNotEmpty)
+                  const SliverToBoxAdapter(
+                    child: Padding(
+                      padding: EdgeInsets.only(bottom: AppSpacing.lg),
+                      child: MomentumCard(),
+                    ),
+                  ),
                 if (pinned.isNotEmpty)
                   SliverToBoxAdapter(
                     child: SizedBox(

--- a/lib/presentation/widgets/momentum_card.dart
+++ b/lib/presentation/widgets/momentum_card.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:percent_indicator/circular_percent_indicator.dart';
+
+import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_spacing.dart';
+import '../../core/theme/app_typography.dart';
+import '../../core/theme/liquid_glass.dart';
+import '../../core/utils/formatting.dart';
+import '../../providers/stats_provider.dart';
+
+/// The "Momentum" summary: a daily-goal progress ring (goal-gradient effect)
+/// plus a streak chain (habit loop / loss aversion). Tapping the goal cycles
+/// the target, so the commitment stays the user's own choice.
+class MomentumCard extends ConsumerWidget {
+  const MomentumCard({super.key});
+
+  static const _goalOptions = [1, 3, 5, 8];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final view = ref.watch(statsViewProvider);
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+
+    final ringColor =
+        view.goalReached ? AppColors.accentGreen : AppColors.accentBlue;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.gutter),
+      child: LiquidGlass(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Row(
+          children: [
+            Semantics(
+              label:
+                  'هدف امروز: ${view.sessionsToday} از ${view.dailyGoal} جلسه',
+              excludeSemantics: true,
+              child: GestureDetector(
+                onTap: () {
+                  final i = _goalOptions.indexOf(view.dailyGoal);
+                  final next = _goalOptions[(i + 1) % _goalOptions.length];
+                  ref.read(statsProvider.notifier).setDailyGoal(next);
+                },
+                child: CircularPercentIndicator(
+                  radius: 34,
+                  lineWidth: 6,
+                  percent: view.goalProgress,
+                  backgroundColor: AppColors.inkSubdued.withValues(alpha: 0.15),
+                  progressColor: ringColor,
+                  circularStrokeCap: CircularStrokeCap.round,
+                  animation: !reduceMotion,
+                  animateFromLastPercent: true,
+                  center: Text(
+                    Fmt.fa('${view.sessionsToday}/${view.dailyGoal}'),
+                    style: AppTypography.caption.copyWith(
+                      fontWeight: FontWeight.w800,
+                      color: AppColors.ink,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.lg),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    view.goalReached ? 'هدف امروز کامل شد 🎉' : 'تمرکز امروز',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.body.copyWith(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'برای تغییر هدف روی حلقه بزن',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.caption,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            _StreakBadge(streak: view.streak),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StreakBadge extends StatelessWidget {
+  const _StreakBadge({required this.streak});
+
+  final int streak;
+
+  @override
+  Widget build(BuildContext context) {
+    final active = streak > 0;
+    return Semantics(
+      label: 'زنجیره: $streak روز پیاپی',
+      excludeSemantics: true,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            active ? CupertinoIcons.flame_fill : CupertinoIcons.flame,
+            color: active ? AppColors.accentOrange : AppColors.inkSubdued,
+            size: 26,
+          ),
+          const SizedBox(height: 2),
+          Text(
+            Fmt.fa('$streak'),
+            style: AppTypography.caption.copyWith(
+              fontWeight: FontWeight.w800,
+              color: active ? AppColors.ink : AppColors.inkSubdued,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/providers/focus_timer_provider.dart
+++ b/lib/providers/focus_timer_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../data/models/task.dart';
+import 'stats_provider.dart';
 import 'task_providers.dart';
 
 /// A focus session's state is always derived from wall-clock time
@@ -127,6 +128,9 @@ class FocusTimerNotifier extends Notifier<FocusSessionState?> {
     final s = state;
     if (s == null || s.completed) return;
     state = s.copyWith(remainingAtSync: 0, runningSince: null, completed: true);
+    // Record the session for streak/goal momentum before the celebratory
+    // haptic, so the completion screen already reflects the new count.
+    await ref.read(statsProvider.notifier).recordCompletedSession();
     await ref.read(hapticsServiceProvider).timerComplete();
     await ref.read(notificationServiceProvider).cancel(
           _focusNotificationIdOffset + s.task.id,

--- a/lib/providers/stats_provider.dart
+++ b/lib/providers/stats_provider.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../data/models/focus_stats.dart';
+import '../data/repositories/stats_repository.dart';
+
+final statsRepositoryProvider = Provider<StatsRepository>((ref) {
+  return SharedPreferencesStatsRepository();
+});
+
+/// Owns the momentum data. The streak arithmetic lives here so it has one
+/// tested home and the UI only ever reads a resolved [FocusStatsView].
+class StatsNotifier extends AsyncNotifier<FocusStats> {
+  StatsRepository get _repo => ref.read(statsRepositoryProvider);
+
+  @override
+  Future<FocusStats> build() => _repo.load();
+
+  static String _dayKey(DateTime d) => '${d.year}-${d.month}-${d.day}';
+
+  /// Records one completed focus session and advances the streak.
+  ///
+  /// - same day as last session → just increment today's count
+  /// - the day after → chain continues, streak += 1
+  /// - a gap (or first ever) → chain restarts at 1
+  ///
+  /// [now] is injectable purely so the logic is unit-testable; callers pass
+  /// nothing and get the real clock.
+  Future<void> recordCompletedSession({DateTime? now}) async {
+    final current = state.valueOrNull ?? const FocusStats();
+    final today = _dayKey(now ?? DateTime.now());
+    final yesterday =
+        _dayKey((now ?? DateTime.now()).subtract(const Duration(days: 1)));
+
+    late FocusStats next;
+    if (current.lastSessionDay == today) {
+      next = current.copyWith(
+        sessionsOnLastDay: current.sessionsOnLastDay + 1,
+        totalSessions: current.totalSessions + 1,
+      );
+    } else {
+      final continues = current.lastSessionDay == yesterday;
+      final newStreak = continues ? current.streak + 1 : 1;
+      next = current.copyWith(
+        sessionsOnLastDay: 1,
+        totalSessions: current.totalSessions + 1,
+        streak: newStreak,
+        longestStreak:
+            newStreak > current.longestStreak ? newStreak : current.longestStreak,
+        lastSessionDay: today,
+      );
+    }
+
+    state = AsyncData(next);
+    await _repo.save(next);
+  }
+
+  Future<void> setDailyGoal(int goal) async {
+    final current = state.valueOrNull ?? const FocusStats();
+    final next = current.copyWith(dailyGoal: goal.clamp(1, 12));
+    state = AsyncData(next);
+    await _repo.save(next);
+  }
+}
+
+final statsProvider = AsyncNotifierProvider<StatsNotifier, FocusStats>(
+  StatsNotifier.new,
+);
+
+/// Date-resolved view for the UI. Recomputed against the current clock each
+/// read so a broken streak shows as zero without a write.
+final statsViewProvider = Provider<FocusStatsView>((ref) {
+  final stats = ref.watch(statsProvider).valueOrNull ?? const FocusStats();
+  return FocusStatsView(stats, DateTime.now());
+});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: app
 description: "Nava - A minimalist productivity app inspired by Jony Ive."
 publish_to: 'none'
-version: 1.1.0+3
+version: 2.0.0+4
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/stats_test.dart
+++ b/test/stats_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:app/data/models/focus_stats.dart';
+import 'package:app/data/repositories/stats_repository.dart';
+import 'package:app/providers/stats_provider.dart';
+
+class _FakeStatsRepository implements StatsRepository {
+  FocusStats stored = const FocusStats();
+
+  @override
+  Future<FocusStats> load() async => stored;
+
+  @override
+  Future<void> save(FocusStats stats) async => stored = stats;
+}
+
+void main() {
+  late ProviderContainer container;
+  late _FakeStatsRepository repo;
+
+  setUp(() async {
+    repo = _FakeStatsRepository();
+    container = ProviderContainer(
+      overrides: [statsRepositoryProvider.overrideWithValue(repo)],
+    );
+    // Ensure the AsyncNotifier has finished its initial build.
+    await container.read(statsProvider.future);
+  });
+
+  tearDown(() => container.dispose());
+
+  StatsNotifier notifier() => container.read(statsProvider.notifier);
+  FocusStats current() => container.read(statsProvider).value!;
+
+  test('first session starts a streak of 1', () async {
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 10));
+    final s = current();
+    expect(s.streak, 1);
+    expect(s.sessionsOnLastDay, 1);
+    expect(s.totalSessions, 1);
+    expect(s.longestStreak, 1);
+  });
+
+  test('two sessions same day do not advance the streak', () async {
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 9));
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 15));
+    final s = current();
+    expect(s.streak, 1);
+    expect(s.sessionsOnLastDay, 2);
+    expect(s.totalSessions, 2);
+  });
+
+  test('a session the next day continues the chain', () async {
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 9));
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 2, 9));
+    final s = current();
+    expect(s.streak, 2);
+    expect(s.sessionsOnLastDay, 1);
+    expect(s.longestStreak, 2);
+  });
+
+  test('a missed day restarts the chain at 1', () async {
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 9));
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 2, 9));
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 5, 9)); // gap
+    final s = current();
+    expect(s.streak, 1);
+    expect(s.longestStreak, 2, reason: 'best streak is preserved');
+    expect(s.totalSessions, 3);
+  });
+
+  test('view resolves a broken streak to zero and today counts to zero',
+      () async {
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 9));
+    // Three days later, before any new session.
+    final view = FocusStatsView(current(), DateTime(2026, 1, 4, 8));
+    expect(view.streak, 0, reason: 'chain expired');
+    expect(view.sessionsToday, 0);
+    expect(view.goalReached, isFalse);
+  });
+
+  test('goal progress clamps to the daily goal', () async {
+    await notifier().setDailyGoal(2);
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 8));
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 10));
+    await notifier().recordCompletedSession(now: DateTime(2026, 1, 1, 12));
+    final view = FocusStatsView(current(), DateTime(2026, 1, 1, 13));
+    expect(view.sessionsToday, 3);
+    expect(view.goalProgress, 1.0);
+    expect(view.goalReached, isTrue);
+  });
+}


### PR DESCRIPTION
Adds an evidence-based momentum system to turn Nava from a passive task list into an app that actively builds a focus habit:

- Daily focus goal + progress ring (goal-gradient effect): a tappable target with a ring that fills as sessions complete.
- Streak / "don't break the chain" (habit loop + loss aversion): consecutive-day streak with a flame badge; expires cleanly when a day is missed (resolved against the current date, never stale).
- Session → task completion loop (Zeigarnik effect): the focus completion screen offers to mark the task done, closing the open loop.
- Break suggestion after a session (ultradian rhythm): a gentle recovery nudge post-focus.
- Completed sessions are recorded to persistent stats (streak, longest streak, totals, daily goal) via a new Riverpod stats layer.

Architecture: new data/models/focus_stats.dart (+ date-resolved FocusStatsView), data/repositories/stats_repository.dart, and providers/stats_provider.dart with the streak arithmetic isolated for testing. focus timer records a session on genuine completion only.

Tests: new test/stats_test.dart unit-tests the streak logic (same-day, next-day, gap, broken-streak resolution, goal clamping).

Bumps version to 2.0.0+4.