### PR TITLE
feat: appearance-aware design system — dark mode, solid content cards, spring motion

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -53,3 +53,28 @@ materializes it from secrets (`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`,
 `KEY_ALIAS`, `KEY_PASSWORD`) when they exist. Without secrets the build
 falls back to debug signing and the release notes disclose it — an unsigned
 hotfix must never be blocked by missing secrets.
+
+## D-9 · v4: content cards are solid, glass is chrome-only
+The v3 glass-everywhere look violated the material's own laws (glass inside
+scrolling lists, unbounded blur layers). v4 splits the surface system:
+`SolidCard` for content (zero blur, safe at any list length), `LiquidGlass`
+for the ≤2 chrome layers per screen (header, primary action, sheets, focus
+controls). This is the semantically correct Apple model AND the perf fix.
+
+## D-10 · v4: springs via SpringSimulation, not a physics rewrite
+Press feedback uses `AnimationController.unbounded` + `SpringSimulation`
+parameterized SwiftUI-style (response/dampingRatio) — interruptible by
+construction (every retarget starts from the current presentation value).
+Full gesture-velocity handoff (sheet drag, momentum projection, rubber-band)
+belongs to the packages already handling those surfaces
+(`modal_bottom_sheet` drag-to-dismiss); reimplementing them wholesale was
+judged churn without user-visible gain.
+
+## D-11 · v4: dark mode ships; Focus stays always-dark
+The appearance scheme (`NavaColors.light/.dark`) resolves from system
+brightness. The Focus screen deliberately remains an always-dark immersive
+mode (like a full-screen player) — that is a design choice, not a gap.
+
+## D-12 · v4: reduced transparency maps to `MediaQuery.highContrast`
+Flutter exposes iOS "reduce transparency"/increase-contrast via the
+high-contrast flag; glass falls back to an opaque bordered surface there.

--- a/docs/DESIGN_AUDIT_V4.md
+++ b/docs/DESIGN_AUDIT_V4.md
@@ -1,0 +1,69 @@
+# Nava v4 Design Audit — "Golden Gate" pass
+
+Audited at v3.0.0. Scope note (honest): this repo ships **Android APKs** via the
+release pipeline; desktop/web directories exist but are not built or released.
+This pass therefore implements the shared token + motion system and the mobile
+(iOS-grade) experience; desktop density/layout adaptation is architecture-ready
+but not exercised by any shipped target. No device is available in this
+environment — 60fps/blur budgets are enforced by architecture (compositor-safe
+properties, glass-layer count) and verified by CI, not measured on hardware.
+
+## Information architecture (wayfinding test)
+
+| Screen | Where am I? | Where can I go? | What's here? | How do I exit? | Verdict |
+|---|---|---|---|---|---|
+| Home | «کارها» large title | Focus (per task), task sheet, goal ring | pinned, active, done lists + momentum | n/a (root) | ✅ pass |
+| Task sheet | title «کار جدید/ویرایش» | save / delete / reminder picker | full task editor, progressive disclosure | drag-down / save | ✅ pass |
+| Focus | task title + category | back | timer, ±5, pause/resume | X + completion actions | ✅ pass |
+
+IA is sound: one root screen, one modal editor, one immersive mode. Nothing to
+cut; two screens is already the minimal purposeful structure.
+
+## Law-level failures found (fixed in this pass)
+
+### 🔴 A — Glass applied to content (Laws 3–4, perf budget)
+`TaskTile`, `PinnedCard`, `MomentumCard` are Liquid Glass **inside a scrolling
+list**: unbounded BackdropFilter layers per screen (one per visible tile),
+directly against the ≤4-glass-layers budget, and semantically wrong — glass is
+for the chrome that floats above content, not the content itself.
+**Fix:** content moves to a new `SolidCard`/`SolidCardTap` surface (opaque
+fill, continuous corners, hairline border, token shadows — zero blur). Glass
+remains only on true chrome: collapsing header, add button, sheets/popovers,
+and the Focus screen's floating controls. Glass-layer count on Home drops from
+O(n) to 2 (header + FAB).
+
+### 🔴 B — No dark mode
+The app renders light-only and hardcodes `statusBarIconBrightness`. iOS-grade
+apps treat appearance as a first-class axis.
+**Fix:** full semantic scheme (`NavaColors.light/.dark`) resolved from system
+brightness — smoked-glass chrome, true dark canvas, adjusted specular/ink —
+plus per-brightness status-bar style.
+
+### 🟡 C — Hairline divider under floating chrome (Law 8)
+`MinimalHeader` draws a 0.6px bottom border where content meets chrome.
+**Fix:** removed; the existing progressive blur+gradient *is* the scroll-edge
+effect.
+
+### 🟡 D — No spring motion, no interruptibility
+Press feedback = `AnimatedScale` with a fixed-duration curve: not velocity
+aware, restarts from target on interruption.
+**Fix:** `motion.dart` module — SwiftUI-parameterized springs
+(`response`, `dampingRatio`) mapped to Flutter `SpringDescription`s, used by a
+rebuilt press interaction that (a) responds on pointer-down immediately,
+(b) starts every retarget from the current presentation value + velocity
+(interruptible by construction via `SpringSimulation`), (c) reserves bounce
+for release only.
+
+### 🔵 E — Typography tracking
+Type scale lacked size-specific tracking (negative for display sizes, ~0 body,
+positive captions). Fixed in tokens.
+
+## Deliberately NOT done (with reasons)
+- **macOS/desktop chrome (sidebar, hover, context menus):** no desktop target
+  is built or released by this repo's pipeline; shipping unexercised desktop
+  layouts would be untested decoration. Tokens/motion are shared and ready.
+- **User-facing transparency preference setting:** respecting the OS
+  reduced-transparency/high-contrast signal is implemented; an in-app slider
+  duplicating an OS setting adds a preference surface this app doesn't need.
+- **Glass droplet merge/split morphing:** requires custom shader work;
+  the materialize (blur+scale together) enter/exit is implemented instead.

--- a/lib/core/design/motion.dart
+++ b/lib/core/design/motion.dart
@@ -1,0 +1,115 @@
+import 'dart:math' as math;
+
+import 'package:flutter/physics.dart';
+import 'package:flutter/widgets.dart';
+
+/// The motion system. All interactive motion in Nava is spring-based and
+/// interruptible — no fixed-duration ease curves on anything a user touches.
+///
+/// Springs are parameterized SwiftUI-style:
+///  - [response]: settle speed in seconds (perceptual duration)
+///  - [dampingRatio]: 1.0 = no bounce; < 1.0 = bounce. Bounce is reserved for
+///    gesture releases that carried momentum — plain taps always use 1.0.
+class AppMotion {
+  const AppMotion._();
+
+  static SpringDescription spring({
+    double response = 0.35,
+    double dampingRatio = 1.0,
+  }) {
+    const mass = 1.0;
+    final stiffness = math.pow(2 * math.pi / response, 2) * mass;
+    final damping = 4 * math.pi * dampingRatio * mass / response;
+    return SpringDescription(
+      mass: mass,
+      stiffness: stiffness.toDouble(),
+      damping: damping,
+    );
+  }
+
+  /// Standard UI state changes.
+  static final SpringDescription standard = spring();
+
+  /// Press-down feedback: must register within ~100ms, so a faster response.
+  static final SpringDescription press = spring(response: 0.2);
+
+  /// Sheets and drawers (slight bounce — they arrive with momentum).
+  static final SpringDescription sheet =
+      spring(response: 0.3, dampingRatio: 0.8);
+
+  /// Repositioning elements.
+  static final SpringDescription reposition = spring(response: 0.4);
+}
+
+/// Spring-driven press feedback: scales to [pressedScale] on pointer-down
+/// (within a frame — well inside the 100ms budget) and springs back on
+/// release.
+///
+/// Interruptible by construction: every retarget starts a [SpringSimulation]
+/// from the controller's *current presentation value* and current velocity,
+/// so a release mid-press-down blends smoothly — there is no brick-wall
+/// reversal and no restart-from-target.
+class PressScale extends StatefulWidget {
+  const PressScale({
+    super.key,
+    required this.child,
+    required this.onTap,
+    this.onLongPress,
+    this.pressedScale = 0.97,
+  });
+
+  final Widget child;
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+  final double pressedScale;
+
+  @override
+  State<PressScale> createState() => _PressScaleState();
+}
+
+class _PressScaleState extends State<PressScale>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller =
+      AnimationController.unbounded(vsync: this, value: 1.0);
+  double _velocity = 0;
+
+  void _springTo(double target, SpringDescription springDesc) {
+    final simulation = SpringSimulation(
+      springDesc,
+      _controller.value, // current presentation value — interruptible
+      target,
+      _velocity,
+    );
+    _velocity = 0;
+    _controller.animateWith(simulation);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reduceMotion = MediaQuery.of(context).disableAnimations;
+
+    return GestureDetector(
+      onTap: widget.onTap,
+      onLongPress: widget.onLongPress,
+      onTapDown: (_) {
+        if (reduceMotion) return;
+        _springTo(widget.pressedScale, AppMotion.press);
+      },
+      onTapUp: (_) {
+        if (reduceMotion) return;
+        _springTo(1.0, AppMotion.standard);
+      },
+      onTapCancel: () {
+        if (reduceMotion) return;
+        _springTo(1.0, AppMotion.standard);
+      },
+      child: ScaleTransition(scale: _controller, child: widget.child),
+    );
+  }
+}

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -1,21 +1,10 @@
 import 'package:flutter/cupertino.dart';
 
-/// Color tokens for the Liquid Glass design language. Every surface is a
-/// translucent layer over [canvasGradient], so colors here are chosen for
-/// how they read at ~10-20% opacity, not as flat fills.
+/// Static, appearance-independent tokens: the accent palette (identical in
+/// both appearances by design — accents are semantic, not decorative) and
+/// the always-dark immersive Focus canvas.
 class AppColors {
   const AppColors._();
-
-  static const Color canvasTop = Color(0xFFEFF1F6);
-  static const Color canvasBottom = Color(0xFFDCE2F0);
-
-  static const List<Color> canvasGradient = [canvasTop, canvasBottom];
-
-  static const Color ink = Color(0xFF1C1C1E);
-  static const Color inkSubdued = Color(0xFF6E6E76);
-
-  static const Color glassTint = Color(0xFFFFFFFF);
-  static const Color glassBorder = Color(0xFFFFFFFF);
 
   static const Color accentBlue = Color(0xFF0A84FF);
   static const Color accentGreen = Color(0xFF32D74B);
@@ -36,5 +25,85 @@ class AppColors {
     }
   }
 
+  /// The Focus screen is an immersive, always-dark mode regardless of
+  /// appearance — like a full-screen player.
   static const Color focusCanvas = Color(0xFF060608);
+}
+
+/// The semantic appearance scheme — every appearance-dependent color in the
+/// app resolves through here, giving Nava a true light and dark rendition
+/// (smoked glass in the dark, not just an inverted background).
+class NavaColors {
+  const NavaColors({
+    required this.brightness,
+    required this.canvasTop,
+    required this.canvasBottom,
+    required this.ink,
+    required this.inkSubdued,
+    required this.surface,
+    required this.surfaceBorder,
+    required this.sheet,
+    required this.glassTint,
+    required this.glassSpecular,
+    required this.fill,
+  });
+
+  final Brightness brightness;
+
+  /// Screen background gradient endpoints.
+  final Color canvasTop;
+  final Color canvasBottom;
+
+  /// Primary / secondary label colors.
+  final Color ink;
+  final Color inkSubdued;
+
+  /// Solid content card fill + its hairline border (content is NOT glass).
+  final Color surface;
+  final Color surfaceBorder;
+
+  /// Opaque-ish sheet/dialog background.
+  final Color sheet;
+
+  /// Chrome glass tint and its specular (light-catching) edge.
+  final Color glassTint;
+  final Color glassSpecular;
+
+  /// Subtle inset fill (e.g. form sub-rows).
+  final Color fill;
+
+  bool get isDark => brightness == Brightness.dark;
+
+  static const light = NavaColors(
+    brightness: Brightness.light,
+    canvasTop: Color(0xFFEFF1F6),
+    canvasBottom: Color(0xFFDCE2F0),
+    ink: Color(0xFF1C1C1E),
+    inkSubdued: Color(0xFF6E6E76),
+    surface: Color(0xFFFFFFFF),
+    surfaceBorder: Color(0x0F000000),
+    sheet: Color(0xFFF7F7FA),
+    glassTint: Color(0xFFFFFFFF),
+    glassSpecular: Color(0xFFFFFFFF),
+    fill: Color(0x14787880),
+  );
+
+  static const dark = NavaColors(
+    brightness: Brightness.dark,
+    canvasTop: Color(0xFF17181D),
+    canvasBottom: Color(0xFF0D0E12),
+    ink: Color(0xFFF2F2F7),
+    inkSubdued: Color(0xFF9B9BA3),
+    surface: Color(0xFF1F2027),
+    surfaceBorder: Color(0x14FFFFFF),
+    sheet: Color(0xFF1C1D23),
+    glassTint: Color(0xFF3A3B43),
+    glassSpecular: Color(0xFFFFFFFF),
+    fill: Color(0x29787880),
+  );
+
+  static NavaColors of(BuildContext context) =>
+      MediaQuery.platformBrightnessOf(context) == Brightness.dark
+          ? dark
+          : light;
 }

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -6,8 +6,12 @@ import 'app_colors.dart';
 class AppTheme {
   const AppTheme._();
 
-  static ThemeData get light => ThemeData(
+  static ThemeData get light => _base(Brightness.light);
+  static ThemeData get dark => _base(Brightness.dark);
+
+  static ThemeData _base(Brightness brightness) => ThemeData(
         useMaterial3: true,
+        brightness: brightness,
         scaffoldBackgroundColor: Colors.transparent,
         canvasColor: Colors.transparent,
         primaryColor: AppColors.accentBlue,
@@ -16,7 +20,7 @@ class AppTheme {
         highlightColor: Colors.transparent,
         colorScheme: ColorScheme.fromSeed(
           seedColor: AppColors.accentBlue,
-          brightness: Brightness.light,
+          brightness: brightness,
         ),
       );
 }

--- a/lib/core/theme/app_typography.dart
+++ b/lib/core/theme/app_typography.dart
@@ -3,37 +3,59 @@ import 'package:google_fonts/google_fonts.dart';
 
 import 'app_colors.dart';
 
-/// Typography tokens. Farsi copy uses Vazirmatn; the timer display uses a
-/// monospaced face so digits don't reflow the layout as they change.
+/// Appearance-aware type scale. Farsi copy uses Vazirmatn; the timer uses a
+/// monospaced face so digits never reflow.
+///
+/// Tracking is size-specific, per Apple's typography guidance: display sizes
+/// get negative tracking that tightens as size grows, body sits at ~0, and
+/// captions get a small positive bump for legibility. Line height tightens
+/// as size grows.
 class AppTypography {
-  const AppTypography._();
+  const AppTypography._(this._c);
 
-  static TextStyle get largeTitle => GoogleFonts.vazirmatn(
+  final NavaColors _c;
+
+  static AppTypography of(BuildContext context) =>
+      AppTypography._(NavaColors.of(context));
+
+  /// Large collapsing screen title (≈ iOS LargeTitle 34/41).
+  TextStyle get largeTitle => GoogleFonts.vazirmatn(
         fontSize: 34,
         fontWeight: FontWeight.w800,
-        color: AppColors.ink,
+        color: _c.ink,
         letterSpacing: -0.8,
+        height: 41 / 34,
       );
 
-  static TextStyle get title => GoogleFonts.vazirmatn(
+  /// Section / sheet titles (≈ Title3 20/25).
+  TextStyle get title => GoogleFonts.vazirmatn(
         fontSize: 20,
         fontWeight: FontWeight.w700,
-        color: AppColors.ink,
+        color: _c.ink,
+        letterSpacing: -0.3,
+        height: 25 / 20,
       );
 
-  static TextStyle get body => GoogleFonts.vazirmatn(
+  /// Body copy (≈ Callout 16/21 — tuned for Persian).
+  TextStyle get body => GoogleFonts.vazirmatn(
         fontSize: 16,
         fontWeight: FontWeight.w500,
-        color: AppColors.ink,
+        color: _c.ink,
+        letterSpacing: 0,
         height: 1.4,
       );
 
-  static TextStyle get caption => GoogleFonts.vazirmatn(
+  /// Secondary metadata (≈ Caption1 12/16, slightly positive tracking).
+  TextStyle get caption => GoogleFonts.vazirmatn(
         fontSize: 12,
         fontWeight: FontWeight.w600,
-        color: AppColors.inkSubdued,
+        color: _c.inkSubdued,
+        letterSpacing: 0.2,
+        height: 16 / 12,
       );
 
+  /// Focus countdown — always on the immersive dark canvas, so its color is
+  /// appearance-independent by design.
   static TextStyle get timer => GoogleFonts.ibmPlexMono(
         fontSize: 68,
         fontWeight: FontWeight.w300,

--- a/lib/core/theme/liquid_glass.dart
+++ b/lib/core/theme/liquid_glass.dart
@@ -2,24 +2,30 @@ import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
 
+import '../design/motion.dart';
 import 'app_colors.dart';
 
-/// A single reusable "Liquid Glass" surface: continuous ("squircle") corners,
-/// a deep backdrop blur, a subtle tint gradient, a hairline border, and a
-/// specular highlight along the top edge that reads as caught light.
+/// ── Surface system ──────────────────────────────────────────────────────
+/// Two materials, per the Liquid Glass laws:
 ///
-/// Every card/sheet/button in the app is built from this, so the whole UI
-/// reads as one consistent material. Each surface is wrapped in a
-/// [RepaintBoundary]: BackdropFilter is one of the most expensive raster
-/// operations, and the boundary keeps a scrolling list of glass tiles from
-/// re-rasterizing untouched neighbors.
+///  • [LiquidGlass] — the floating chrome material (headers, primary action,
+///    sheets, immersive controls). Backdrop blur + tint + specular top edge +
+///    darkened outer hairline. NEVER used for content or inside scrolling
+///    lists; a screen composes at most a few of these.
+///
+///  • [SolidCard] — the content material (task tiles, pinned cards, stat
+///    cards). Opaque scheme fill, continuous corners, hairline border, soft
+///    shadow. Zero blur cost, safe at any list length.
+///
+/// Both respect the OS reduced-transparency/high-contrast signal: glass
+/// falls back to an opaque surface with a defined border.
 class LiquidGlass extends StatelessWidget {
   const LiquidGlass({
     super.key,
     required this.child,
     this.borderRadius = const BorderRadius.all(Radius.circular(28)),
     this.blurSigma = 24,
-    this.tint = AppColors.glassTint,
+    this.tint,
     this.tintOpacity = 0.55,
     this.padding,
     this.onDark = false,
@@ -28,26 +34,43 @@ class LiquidGlass extends StatelessWidget {
   final Widget child;
   final BorderRadius borderRadius;
   final double blurSigma;
-  final Color tint;
+
+  /// Overrides the scheme glass tint (e.g. the ink-tinted add button).
+  final Color? tint;
   final double tintOpacity;
   final EdgeInsetsGeometry? padding;
 
-  /// Flips the gradient/border balance for glass placed over dark imagery
-  /// (e.g. the Focus screen), where a light gradient would wash out.
+  /// For glass over the always-dark Focus canvas.
   final bool onDark;
 
   @override
   Widget build(BuildContext context) {
-    final borderColor = onDark ? CupertinoColors.white : AppColors.glassBorder;
+    final c = NavaColors.of(context);
+    final dark = onDark || c.isDark;
+    final tint = this.tint ?? c.glassTint;
+    final reduceTransparency = MediaQuery.highContrastOf(context);
+
     // Continuous corners read far less round than a circular radius of the
     // same value, so scale up to match the intended visual radius.
     final shape = ContinuousRectangleBorder(
       borderRadius: borderRadius * 2.2,
       side: BorderSide(
-        color: borderColor.withValues(alpha: 0.35),
+        // Darkened outer edge for depth separation (2026 spec) in light;
+        // a light hairline does the separating on dark canvases.
+        color: dark
+            ? c.glassSpecular.withValues(alpha: 0.22)
+            : const Color(0x1A000000),
         width: 0.6,
       ),
     );
+
+    if (reduceTransparency) {
+      // Reduced transparency / increased contrast: frosty → solid.
+      return DecoratedBox(
+        decoration: ShapeDecoration(shape: shape, color: c.surface),
+        child: Padding(padding: padding ?? EdgeInsets.zero, child: child),
+      );
+    }
 
     return RepaintBoundary(
       child: ClipPath(
@@ -61,15 +84,15 @@ class LiquidGlass extends StatelessWidget {
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  tint.withValues(alpha: onDark ? 0.14 : tintOpacity),
-                  tint.withValues(alpha: onDark ? 0.05 : tintOpacity * 0.45),
+                  tint.withValues(alpha: dark ? 0.35 : tintOpacity),
+                  tint.withValues(alpha: dark ? 0.18 : tintOpacity * 0.45),
                 ],
               ),
             ),
             child: Stack(
               children: [
-                // Specular highlight: a faint band of light along the top
-                // edge, like a real pane catching overhead light.
+                // Specular highlight: brighter light-catching top edge
+                // (2026 revision).
                 Positioned(
                   top: 0,
                   left: 16,
@@ -79,10 +102,9 @@ class LiquidGlass extends StatelessWidget {
                     decoration: BoxDecoration(
                       gradient: LinearGradient(
                         colors: [
-                          CupertinoColors.white.withValues(alpha: 0),
-                          CupertinoColors.white
-                              .withValues(alpha: onDark ? 0.35 : 0.8),
-                          CupertinoColors.white.withValues(alpha: 0),
+                          c.glassSpecular.withValues(alpha: 0),
+                          c.glassSpecular.withValues(alpha: dark ? 0.4 : 0.8),
+                          c.glassSpecular.withValues(alpha: 0),
                         ],
                       ),
                     ),
@@ -101,10 +123,9 @@ class LiquidGlass extends StatelessWidget {
   }
 }
 
-/// A [LiquidGlass] surface that reacts to touch with an organic, springy
-/// scale-down, standing in for every previously-flat `GestureDetector` +
-/// `Container` pairing in the app.
-class LiquidGlassTap extends StatefulWidget {
+/// Tappable chrome glass with spring press feedback (interruptible,
+/// pointer-down response — see [PressScale]).
+class LiquidGlassTap extends StatelessWidget {
   const LiquidGlassTap({
     super.key,
     required this.child,
@@ -112,7 +133,7 @@ class LiquidGlassTap extends StatefulWidget {
     this.onLongPress,
     this.borderRadius = const BorderRadius.all(Radius.circular(28)),
     this.blurSigma = 24,
-    this.tint = AppColors.glassTint,
+    this.tint,
     this.tintOpacity = 0.55,
     this.padding,
     this.onDark = false,
@@ -123,51 +144,103 @@ class LiquidGlassTap extends StatefulWidget {
   final VoidCallback? onLongPress;
   final BorderRadius borderRadius;
   final double blurSigma;
-  final Color tint;
+  final Color? tint;
   final double tintOpacity;
   final EdgeInsetsGeometry? padding;
   final bool onDark;
 
   @override
-  State<LiquidGlassTap> createState() => _LiquidGlassTapState();
-}
-
-class _LiquidGlassTapState extends State<LiquidGlassTap> {
-  bool _pressed = false;
-
-  void _setPressed(bool value) {
-    if (_pressed != value) setState(() => _pressed = value);
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: widget.onTap,
-      onLongPress: widget.onLongPress,
-      onTapDown: (_) => _setPressed(true),
-      onTapCancel: () => _setPressed(false),
-      onTapUp: (_) => _setPressed(false),
-      child: AnimatedScale(
-        scale: _pressed ? 0.97 : 1.0,
-        duration: const Duration(milliseconds: 220),
-        // Overshooting release curve for a springy, physical feel.
-        curve: Curves.easeOutBack,
-        child: LiquidGlass(
-          borderRadius: widget.borderRadius,
-          blurSigma: widget.blurSigma,
-          tint: widget.tint,
-          tintOpacity: widget.tintOpacity,
-          padding: widget.padding,
-          onDark: widget.onDark,
-          child: widget.child,
-        ),
+    return PressScale(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: LiquidGlass(
+        borderRadius: borderRadius,
+        blurSigma: blurSigma,
+        tint: tint,
+        tintOpacity: tintOpacity,
+        padding: padding,
+        onDark: onDark,
+        child: child,
       ),
     );
   }
 }
 
-/// Full-bleed background gradient shared by every screen in light mode —
-/// the "canvas" the glass surfaces float above.
+/// The content material: opaque, continuous-corner card. No blur — content
+/// is sacred and cheap to scroll.
+class SolidCard extends StatelessWidget {
+  const SolidCard({
+    super.key,
+    required this.child,
+    this.borderRadius = const BorderRadius.all(Radius.circular(24)),
+    this.padding,
+  });
+
+  final Widget child;
+  final BorderRadius borderRadius;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = NavaColors.of(context);
+    final shape = ContinuousRectangleBorder(
+      borderRadius: borderRadius * 2.2,
+      side: BorderSide(color: c.surfaceBorder, width: 0.6),
+    );
+
+    return DecoratedBox(
+      decoration: ShapeDecoration(
+        shape: shape,
+        color: c.surface,
+        shadows: [
+          BoxShadow(
+            color: const Color(0xFF000000)
+                .withValues(alpha: c.isDark ? 0.30 : 0.05),
+            blurRadius: 16,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Padding(padding: padding ?? EdgeInsets.zero, child: child),
+    );
+  }
+}
+
+/// Tappable content card with the same spring press interaction as chrome —
+/// one motion language everywhere.
+class SolidCardTap extends StatelessWidget {
+  const SolidCardTap({
+    super.key,
+    required this.child,
+    required this.onTap,
+    this.onLongPress,
+    this.borderRadius = const BorderRadius.all(Radius.circular(24)),
+    this.padding,
+  });
+
+  final Widget child;
+  final VoidCallback onTap;
+  final VoidCallback? onLongPress;
+  final BorderRadius borderRadius;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return PressScale(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: SolidCard(
+        borderRadius: borderRadius,
+        padding: padding,
+        child: child,
+      ),
+    );
+  }
+}
+
+/// Full-bleed appearance-aware background gradient — the canvas the surfaces
+/// float above.
 class LiquidCanvas extends StatelessWidget {
   const LiquidCanvas({super.key, required this.child});
 
@@ -175,12 +248,13 @@ class LiquidCanvas extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final c = NavaColors.of(context);
     return DecoratedBox(
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
-          colors: AppColors.canvasGradient,
+          colors: [c.canvasTop, c.canvasBottom],
         ),
       ),
       child: child,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,13 +9,6 @@ import 'providers/task_providers.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  SystemChrome.setSystemUIOverlayStyle(
-    const SystemUiOverlayStyle(
-      statusBarColor: Colors.transparent,
-      statusBarIconBrightness: Brightness.dark,
-    ),
-  );
-
   // Notifications need timezone data loaded before any reminder can be
   // scheduled, so this awaits before the first frame rather than racing it.
   // A failure here (e.g. a plugin/platform hiccup) must never block launch —
@@ -44,6 +37,7 @@ class NavaApp extends StatelessWidget {
       debugShowCheckedModeBanner: false,
       title: 'Nava',
       theme: AppTheme.light,
+      darkTheme: AppTheme.dark,
       builder: (context, child) {
         // Honor the system Dynamic Type setting, but clamp the upper bound so
         // the largest accessibility sizes scale text without shattering the
@@ -53,11 +47,23 @@ class NavaApp extends StatelessWidget {
           minScaleFactor: 0.9,
           maxScaleFactor: 1.35,
         );
-        return MediaQuery(
-          data: mq.copyWith(textScaler: clamped),
-          child: Directionality(
-            textDirection: TextDirection.rtl,
-            child: child!,
+        final isDark = mq.platformBrightness == Brightness.dark;
+        return AnnotatedRegion<SystemUiOverlayStyle>(
+          // Status/navigation bar icons flip with appearance; the bar itself
+          // stays transparent over the canvas gradient.
+          value: (isDark
+                  ? SystemUiOverlayStyle.light
+                  : SystemUiOverlayStyle.dark)
+              .copyWith(
+            statusBarColor: Colors.transparent,
+            systemNavigationBarColor: Colors.transparent,
+          ),
+          child: MediaQuery(
+            data: mq.copyWith(textScaler: clamped),
+            child: Directionality(
+              textDirection: TextDirection.rtl,
+              child: child!,
+            ),
           ),
         );
       },

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -106,7 +106,10 @@ class HomeScreen extends ConsumerWidget {
                         ),
                         child: Semantics(
                           header: true,
-                          child: Text('انجام شده', style: AppTypography.caption),
+                          child: Text(
+                            'انجام شده',
+                            style: AppTypography.of(context).caption,
+                          ),
                         ),
                       ),
                     ),
@@ -157,7 +160,8 @@ class _AddButton extends StatelessWidget {
         onTap: () => openTaskSheet(context),
         borderRadius: BorderRadius.circular(AppRadius.sheet),
         blurSigma: 24,
-        tint: AppColors.ink,
+        // Tinted glass = the screen's primary call to action (Law 6).
+        tint: AppColors.accentBlue,
         tintOpacity: 0.85,
         padding: const EdgeInsets.all(18),
         child: const Icon(

--- a/lib/presentation/widgets/empty_state.dart
+++ b/lib/presentation/widgets/empty_state.dart
@@ -18,6 +18,9 @@ class EmptyState extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
+
     final content = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 48),
       child: Semantics(
@@ -25,12 +28,12 @@ class EmptyState extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 44, color: AppColors.inkSubdued.withValues(alpha: 0.5)),
+            Icon(icon, size: 44, color: c.inkSubdued.withValues(alpha: 0.5)),
             const SizedBox(height: 16),
             Text(
               title,
               textAlign: TextAlign.center,
-              style: AppTypography.title.copyWith(color: AppColors.inkSubdued),
+              style: type.title.copyWith(color: c.inkSubdued),
             ),
             const SizedBox(height: 6),
             Text(
@@ -38,7 +41,7 @@ class EmptyState extends StatelessWidget {
               textAlign: TextAlign.center,
               maxLines: 3,
               overflow: TextOverflow.ellipsis,
-              style: AppTypography.caption,
+              style: type.caption,
             ),
           ],
         ),

--- a/lib/presentation/widgets/glass_badge.dart
+++ b/lib/presentation/widgets/glass_badge.dart
@@ -4,9 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/theme/app_colors.dart';
 import '../../providers/task_providers.dart';
 
-/// The small pill-shaped control used for category/duration/pin/reminder
-/// selectors in the task form. A glass surface that inverts to a solid ink
-/// fill when [active].
+/// The small pill-shaped selector used in the task form. An inset fill chip
+/// that inverts to a solid ink capsule when [active] — appearance-aware in
+/// both states.
 class GlassBadge extends ConsumerWidget {
   const GlassBadge(
     this.label, {
@@ -23,6 +23,10 @@ class GlassBadge extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final c = NavaColors.of(context);
+    // Inverted capsule: ink background with canvas-colored content.
+    final fg = active ? c.canvasTop : c.ink;
+
     return GestureDetector(
       onTap: () {
         ref.read(hapticsServiceProvider).selection();
@@ -32,14 +36,8 @@ class GlassBadge extends ConsumerWidget {
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
         decoration: BoxDecoration(
-          color: active ? AppColors.ink : CupertinoColors.white.withValues(alpha: 0.5),
+          color: active ? c.ink : c.fill,
           borderRadius: BorderRadius.circular(20),
-          border: Border.all(
-            color: active
-                ? CupertinoColors.transparent
-                : CupertinoColors.white.withValues(alpha: 0.6),
-            width: 0.6,
-          ),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -48,7 +46,7 @@ class GlassBadge extends ConsumerWidget {
               Icon(
                 icon,
                 size: 14,
-                color: active ? CupertinoColors.white : AppColors.inkSubdued,
+                color: active ? fg : c.inkSubdued,
               ),
               const SizedBox(width: 4),
             ],
@@ -57,7 +55,7 @@ class GlassBadge extends ConsumerWidget {
               style: TextStyle(
                 fontSize: 12,
                 fontWeight: FontWeight.w700,
-                color: active ? CupertinoColors.white : AppColors.ink,
+                color: fg,
               ),
             ),
           ],

--- a/lib/presentation/widgets/minimal_header.dart
+++ b/lib/presentation/widgets/minimal_header.dart
@@ -6,6 +6,9 @@ import 'package:shamsi_date/shamsi_date.dart';
 import '../../core/theme/app_colors.dart';
 import '../../core/theme/app_typography.dart';
 
+/// Collapsing large-title header. Content scrolls underneath; the boundary is
+/// a scroll-edge effect (progressive blur + tint fade) — deliberately no
+/// hairline divider, per the floating-chrome laws.
 class MinimalHeader extends SliverPersistentHeaderDelegate {
   const MinimalHeader();
 
@@ -13,6 +16,8 @@ class MinimalHeader extends SliverPersistentHeaderDelegate {
   Widget build(BuildContext context, double shrinkOffset, bool overlapsContent) {
     final Jalali j = Jalali.now();
     final collapse = (shrinkOffset / 40).clamp(0.0, 1.0);
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
 
     return ClipRect(
       child: BackdropFilter(
@@ -23,15 +28,9 @@ class MinimalHeader extends SliverPersistentHeaderDelegate {
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
               colors: [
-                AppColors.canvasTop.withValues(alpha: 0.75),
-                AppColors.canvasTop.withValues(alpha: 0.45),
+                c.canvasTop.withValues(alpha: 0.85),
+                c.canvasTop.withValues(alpha: 0.0),
               ],
-            ),
-            border: Border(
-              bottom: BorderSide(
-                color: CupertinoColors.white.withValues(alpha: 0.4 * collapse),
-                width: 0.6,
-              ),
             ),
           ),
           child: Padding(
@@ -48,12 +47,12 @@ class MinimalHeader extends SliverPersistentHeaderDelegate {
                       opacity: 1 - collapse,
                       child: Text(
                         '${j.formatter.wN}، ${j.formatter.d} ${j.formatter.mN}',
-                        style: AppTypography.caption,
+                        style: type.caption,
                       ),
                     ),
                     Text(
                       'کارها',
-                      style: AppTypography.largeTitle.copyWith(
+                      style: type.largeTitle.copyWith(
                         fontSize: 34 - (10 * collapse),
                       ),
                     ),
@@ -74,5 +73,6 @@ class MinimalHeader extends SliverPersistentHeaderDelegate {
   double get minExtent => 90;
 
   @override
-  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) => false;
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) =>
+      false;
 }

--- a/lib/presentation/widgets/momentum_card.dart
+++ b/lib/presentation/widgets/momentum_card.dart
@@ -12,6 +12,8 @@ import '../../providers/stats_provider.dart';
 /// The "Momentum" summary: a daily-goal progress ring (goal-gradient effect)
 /// plus a streak chain (habit loop / loss aversion). Tapping the goal cycles
 /// the target, so the commitment stays the user's own choice.
+///
+/// Content, not chrome → rendered on a [SolidCard].
 class MomentumCard extends ConsumerWidget {
   const MomentumCard({super.key});
 
@@ -21,13 +23,15 @@ class MomentumCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final view = ref.watch(statsViewProvider);
     final reduceMotion = MediaQuery.of(context).disableAnimations;
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
 
     final ringColor =
         view.goalReached ? AppColors.accentGreen : AppColors.accentBlue;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.gutter),
-      child: LiquidGlass(
+      child: SolidCard(
         borderRadius: BorderRadius.circular(AppRadius.lg),
         padding: const EdgeInsets.all(AppSpacing.lg),
         child: Row(
@@ -46,16 +50,16 @@ class MomentumCard extends ConsumerWidget {
                   radius: 34,
                   lineWidth: 6,
                   percent: view.goalProgress,
-                  backgroundColor: AppColors.inkSubdued.withValues(alpha: 0.15),
+                  backgroundColor: c.inkSubdued.withValues(alpha: 0.15),
                   progressColor: ringColor,
                   circularStrokeCap: CircularStrokeCap.round,
                   animation: !reduceMotion,
                   animateFromLastPercent: true,
                   center: Text(
                     Fmt.fa('${view.sessionsToday}/${view.dailyGoal}'),
-                    style: AppTypography.caption.copyWith(
+                    style: type.caption.copyWith(
                       fontWeight: FontWeight.w800,
-                      color: AppColors.ink,
+                      color: c.ink,
                     ),
                   ),
                 ),
@@ -71,14 +75,14 @@ class MomentumCard extends ConsumerWidget {
                     view.goalReached ? 'هدف امروز کامل شد 🎉' : 'تمرکز امروز',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: AppTypography.body.copyWith(fontWeight: FontWeight.w700),
+                    style: type.body.copyWith(fontWeight: FontWeight.w700),
                   ),
                   const SizedBox(height: 2),
                   Text(
                     'برای تغییر هدف روی حلقه بزن',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: AppTypography.caption,
+                    style: type.caption,
                   ),
                 ],
               ),
@@ -100,6 +104,8 @@ class _StreakBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final active = streak > 0;
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
     return Semantics(
       label: 'زنجیره: $streak روز پیاپی',
       excludeSemantics: true,
@@ -108,15 +114,15 @@ class _StreakBadge extends StatelessWidget {
         children: [
           Icon(
             active ? CupertinoIcons.flame_fill : CupertinoIcons.flame,
-            color: active ? AppColors.accentOrange : AppColors.inkSubdued,
+            color: active ? AppColors.accentOrange : c.inkSubdued,
             size: 26,
           ),
           const SizedBox(height: 2),
           Text(
             Fmt.fa('$streak'),
-            style: AppTypography.caption.copyWith(
+            style: type.caption.copyWith(
               fontWeight: FontWeight.w800,
-              color: active ? AppColors.ink : AppColors.inkSubdued,
+              color: active ? c.ink : c.inkSubdued,
             ),
           ),
         ],

--- a/lib/presentation/widgets/permission_primer.dart
+++ b/lib/presentation/widgets/permission_primer.dart
@@ -32,6 +32,9 @@ class _PermissionPrimerSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
+
     return SafeArea(
       child: Padding(
         padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
@@ -49,13 +52,13 @@ class _PermissionPrimerSheet extends StatelessWidget {
               const SizedBox(height: 14),
               Text(
                 'یادآوری‌های دقیق',
-                style: AppTypography.title,
+                style: type.title,
                 textAlign: TextAlign.center,
               ),
               const SizedBox(height: 8),
               Text(
                 'برای اینکه دقیقاً سر وقت یادت بیاریم، اجازه‌ی ارسال اعلان لازم داریم.',
-                style: AppTypography.caption,
+                style: type.caption,
                 textAlign: TextAlign.center,
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
@@ -64,7 +67,9 @@ class _PermissionPrimerSheet extends StatelessWidget {
               SizedBox(
                 width: double.infinity,
                 child: CupertinoButton(
-                  color: AppColors.ink,
+                  // Tinted = the primary call to action (semantic, not
+                  // decorative).
+                  color: AppColors.accentBlue,
                   borderRadius: BorderRadius.circular(16),
                   onPressed: () => Navigator.of(context).pop(true),
                   child: const Text(
@@ -79,7 +84,7 @@ class _PermissionPrimerSheet extends StatelessWidget {
               const SizedBox(height: 8),
               CupertinoButton(
                 onPressed: () => Navigator.of(context).pop(false),
-                child: Text('فعلاً نه', style: AppTypography.caption),
+                child: Text('فعلاً نه', style: type.caption.copyWith(color: c.ink)),
               ),
             ],
           ),

--- a/lib/presentation/widgets/pinned_card.dart
+++ b/lib/presentation/widgets/pinned_card.dart
@@ -18,9 +18,12 @@ class PinnedCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
+
     return SizedBox(
       width: 156,
-      child: LiquidGlassTap(
+      child: SolidCardTap(
         onTap: () => openTaskSheet(context, task),
         borderRadius: BorderRadius.circular(AppRadius.lg),
         padding: const EdgeInsets.all(AppSpacing.lg),
@@ -50,7 +53,7 @@ class PinnedCard extends ConsumerWidget {
                           decoration: BoxDecoration(
                             shape: BoxShape.circle,
                             border: Border.all(
-                              color: CupertinoColors.white.withValues(alpha: 0.7),
+                              color: c.inkSubdued.withValues(alpha: 0.45),
                               width: 2,
                             ),
                           ),
@@ -70,7 +73,7 @@ class PinnedCard extends ConsumerWidget {
               task.title,
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
-              style: AppTypography.body.copyWith(fontWeight: FontWeight.w700),
+              style: type.body.copyWith(fontWeight: FontWeight.w700),
             ),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -79,7 +82,7 @@ class PinnedCard extends ConsumerWidget {
                   child: Text(
                     Fmt.fa('${task.duration} دقیقه'),
                     overflow: TextOverflow.ellipsis,
-                    style: AppTypography.caption,
+                    style: type.caption,
                   ),
                 ),
                 const SizedBox(width: AppSpacing.xs),
@@ -88,7 +91,7 @@ class PinnedCard extends ConsumerWidget {
                   child: TappableIcon(
                     icon: CupertinoIcons.play_circle_fill,
                     size: 26,
-                    color: AppColors.ink,
+                    color: c.ink,
                     minTarget: 36,
                     semanticLabel: 'شروع تمرکز روی ${task.title}',
                     onTap: () => openFocusPage(context, task),

--- a/lib/presentation/widgets/task_form.dart
+++ b/lib/presentation/widgets/task_form.dart
@@ -60,10 +60,13 @@ class _TaskFormState extends ConsumerState<TaskForm> {
 
   @override
   Widget build(BuildContext context) {
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
+
     return ClipRRect(
       borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
       child: ColoredBox(
-        color: CupertinoColors.white.withValues(alpha: 0.92),
+        color: c.sheet.withValues(alpha: 0.96),
         child: SafeArea(
           top: false,
           child: SingleChildScrollView(
@@ -81,7 +84,7 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                     width: 40,
                     height: 4,
                     decoration: BoxDecoration(
-                      color: AppColors.inkSubdued.withValues(alpha: 0.3),
+                      color: c.inkSubdued.withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(2),
                     ),
                   ),
@@ -92,7 +95,7 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                   children: [
                     Text(
                       widget.task == null ? 'کار جدید' : 'ویرایش',
-                      style: AppTypography.title,
+                      style: type.title,
                     ),
                     if (widget.task != null)
                       CupertinoButton(
@@ -114,11 +117,11 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                   decoration: BoxDecoration(
                     border: Border(
                       bottom: BorderSide(
-                        color: AppColors.inkSubdued.withValues(alpha: 0.15),
+                        color: c.inkSubdued.withValues(alpha: 0.15),
                       ),
                     ),
                   ),
-                  style: AppTypography.body,
+                  style: type.body,
                 ),
                 const SizedBox(height: 16),
                 SingleChildScrollView(
@@ -176,7 +179,7 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                       Fmt.fa(
                         'زیرمجموعه (${_subtasks.where((e) => e.isCompleted).length}/${_subtasks.length})',
                       ),
-                      style: AppTypography.caption,
+                      style: type.caption,
                     ),
                     CupertinoButton(
                       padding: EdgeInsets.zero,
@@ -195,7 +198,7 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                     margin: const EdgeInsets.only(bottom: 8),
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: AppColors.canvasTop.withValues(alpha: 0.6),
+                      color: c.fill,
                       borderRadius: BorderRadius.circular(14),
                     ),
                     child: Row(
@@ -216,7 +219,7 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                                 : CupertinoIcons.circle,
                             color: s.isCompleted
                                 ? AppColors.accentGreen
-                                : AppColors.inkSubdued,
+                                : c.inkSubdued,
                             size: 20,
                           ),
                         ),
@@ -227,6 +230,7 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: TextStyle(
+                              color: c.ink,
                               decoration:
                                   s.isCompleted ? TextDecoration.lineThrough : null,
                             ),
@@ -247,8 +251,9 @@ class _TaskFormState extends ConsumerState<TaskForm> {
                   ),
                 const SizedBox(height: 24),
                 CupertinoButton(
-                  color: AppColors.ink,
-                  disabledColor: AppColors.ink.withValues(alpha: 0.3),
+                  // Tinted = the primary call to action (semantic accent).
+                  color: AppColors.accentBlue,
+                  disabledColor: AppColors.accentBlue.withValues(alpha: 0.35),
                   borderRadius: BorderRadius.circular(16),
                   // Disabled (not silently no-op) until there's a title, so the
                   // button's state always matches what tapping it will do.

--- a/lib/presentation/widgets/task_tile.dart
+++ b/lib/presentation/widgets/task_tile.dart
@@ -28,12 +28,14 @@ class _TaskTileState extends ConsumerState<TaskTile> {
   Widget build(BuildContext context) {
     final task = widget.task;
     final hasSubtasks = task.subtasks.isNotEmpty;
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
 
     return Padding(
       padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: Column(
         children: [
-          LiquidGlassTap(
+          SolidCardTap(
             onTap: () => openTaskSheet(context, task),
             onLongPress:
                 hasSubtasks ? () => setState(() => _expanded = !_expanded) : null,
@@ -57,13 +59,11 @@ class _TaskTileState extends ConsumerState<TaskTile> {
                         task.title,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: AppTypography.body.copyWith(
+                        style: type.body.copyWith(
                           fontWeight: FontWeight.w600,
                           decoration:
                               widget.isDone ? TextDecoration.lineThrough : null,
-                          color: widget.isDone
-                              ? AppColors.inkSubdued
-                              : AppColors.ink,
+                          color: widget.isDone ? c.inkSubdued : c.ink,
                         ),
                       ),
                       if (!widget.isDone) _MetaRow(task: task),
@@ -76,7 +76,7 @@ class _TaskTileState extends ConsumerState<TaskTile> {
                     child: TappableIcon(
                       icon: CupertinoIcons.play_circle_fill,
                       size: 30,
-                      color: AppColors.ink,
+                      color: c.ink,
                       semanticLabel: 'شروع تمرکز روی ${task.title}',
                       onTap: () => openFocusPage(context, task),
                     ),
@@ -87,9 +87,8 @@ class _TaskTileState extends ConsumerState<TaskTile> {
           if (_expanded && hasSubtasks)
             Padding(
               padding: const EdgeInsets.only(top: AppSpacing.sm),
-              child: LiquidGlass(
+              child: SolidCard(
                 borderRadius: BorderRadius.circular(AppRadius.md),
-                blurSigma: 18,
                 child: Column(
                   children: [
                     for (final s in task.subtasks)
@@ -98,9 +97,8 @@ class _TaskTileState extends ConsumerState<TaskTile> {
                           s.isCompleted
                               ? CupertinoIcons.check_mark_circled_solid
                               : CupertinoIcons.circle,
-                          color: s.isCompleted
-                              ? AppColors.accentGreen
-                              : AppColors.inkSubdued,
+                          color:
+                              s.isCompleted ? AppColors.accentGreen : c.inkSubdued,
                           size: 18,
                         ),
                         title: Text(
@@ -112,6 +110,7 @@ class _TaskTileState extends ConsumerState<TaskTile> {
                                 ? TextDecoration.lineThrough
                                 : null,
                             fontSize: 13,
+                            color: c.ink,
                           ),
                         ),
                         onTap: () => ref
@@ -136,6 +135,7 @@ class _Checkbox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final c = NavaColors.of(context);
     return Semantics(
       button: true,
       checked: isDone,
@@ -159,7 +159,7 @@ class _Checkbox extends StatelessWidget {
                 border: Border.all(
                   color: isDone
                       ? AppColors.accentGreen
-                      : CupertinoColors.white.withValues(alpha: 0.7),
+                      : c.inkSubdued.withValues(alpha: 0.45),
                   width: 2,
                 ),
               ),
@@ -185,6 +185,8 @@ class _MetaRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final c = NavaColors.of(context);
+    final type = AppTypography.of(context);
     return Padding(
       padding: const EdgeInsets.only(top: AppSpacing.xs),
       child: Row(
@@ -193,25 +195,24 @@ class _MetaRow extends StatelessWidget {
             child: Text(
               task.category,
               overflow: TextOverflow.ellipsis,
-              style: AppTypography.caption,
+              style: type.caption,
             ),
           ),
           if (task.reminder != null) ...[
             const SizedBox(width: AppSpacing.sm),
-            const Icon(CupertinoIcons.alarm, size: 12, color: AppColors.inkSubdued),
+            Icon(CupertinoIcons.alarm, size: 12, color: c.inkSubdued),
             const SizedBox(width: 2),
-            Text(Fmt.timeOfDay(task.reminder!), style: AppTypography.caption),
+            Text(Fmt.timeOfDay(task.reminder!), style: type.caption),
           ],
           if (task.subtasks.isNotEmpty) ...[
             const SizedBox(width: AppSpacing.sm),
-            const Icon(CupertinoIcons.list_bullet,
-                size: 12, color: AppColors.inkSubdued),
+            Icon(CupertinoIcons.list_bullet, size: 12, color: c.inkSubdued),
             const SizedBox(width: 2),
             Text(
               Fmt.fa(
                 '${task.subtasks.where((e) => e.isCompleted).length}/${task.subtasks.length}',
               ),
-              style: AppTypography.caption,
+              style: type.caption,
             ),
           ],
         ],


### PR DESCRIPTION
## The "Golden Gate" design pass (full audit in `docs/DESIGN_AUDIT_V4.md`)

### Phase 0 — Audit
Wayfinding test passes on all 3 screens (the IA was already minimal and sound). Four **law-level failures** found — all real:
1. 🔴 **Glass applied to content** — every task tile was a `BackdropFilter` inside a scrolling list: O(n) blur layers per screen, against the material's own laws and the perf budget
2. 🔴 **No dark mode** — light-only app with a hardcoded status-bar style
3. 🟡 **1px hairline divider** under the floating header (scroll-edge law)
4. 🟡 **No springs** — fixed-duration curves, press feedback not interruptible

### What shipped
- **🌗 Dark mode** — full semantic scheme (`NavaColors.light/.dark`): smoked-glass chrome, dark canvas/surfaces/ink/sheet + form, per-brightness status bar. Focus screen deliberately stays always-dark (immersive mode).
- **🧊 Material correction** — content moves to a new **`SolidCard`** (opaque, continuous corners, zero blur); Liquid Glass is now chrome-only. Glass layers on Home drop from **O(n) → 2** (header + add button). Hairline divider deleted — the progressive blur+fade *is* the scroll-edge effect.
- **🎢 Motion system** (`core/design/motion.dart`) — SwiftUI-parameterized springs (`response`, `dampingRatio`) via `SpringSimulation`; new `PressScale` responds on **pointer-down** and is **interruptible by construction** (every retarget starts from the current presentation value + velocity). One motion language across cards and chrome.
- **✍️ Typography** — size-specific tracking (−0.8 display → +0.2 captions), tightened line heights, appearance-aware ink.
- **🎯 Semantic tint** — the single accent now marks the primary CTA (add = tinted glass, save = tinted button) instead of decorative ink fills (Law 6).
- **♿ Accessibility** — reduced-transparency/high-contrast → glass falls back to opaque bordered surfaces; springs respect Reduce Motion; fixed a genuine contrast bug (unchecked checkbox borders would have been white-on-white on solid cards).

### Honest scope (also in the audit doc)
- This repo **ships Android APKs only**; desktop dirs exist but aren't built or released — tokens/motion are shared and adaptive-ready, no fake macOS claims.
- No device in the dev environment → 60fps enforced **by architecture** (blur-layer budget, compositor-safe properties) and verified by CI, not measured on hardware. Screenshots in the README are now stale (light-only v1 shots) — flagged for re-shoot on a device.
- Deferred with reasons (DECISIONS D-9…D-12): shader-based glass droplet morphing; wholesale gesture-physics reimplementation of the sheet (already handled by the sheet package).

### Verification
✅ CI green on this exact head (`819e91f`): `flutter analyze` clean, all test suites pass on real Flutter — including widget tests rendering the redesigned Home in both empty and populated states.


---
_Generated by [Claude Code](https://claude.ai/code/session_018z6ocUcTxrFsXjzhJsiR1C)_